### PR TITLE
Default agent-shell-start wrapper and Emacs-native bootstrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.agent-shell/

--- a/README.org
+++ b/README.org
@@ -63,57 +63,51 @@ M-x meta-agent-shell-setup
 
 This:
 1. Creates =~/.claude-meta/= directory
-2. Links the meta-agent CLAUDE.md
-3. Tells you what to add to your shell config and =~/.claude/CLAUDE.md=
+2. Syncs support scripts and prompts into =~/.meta-agent-shell/=
+3. Adds the support script directory to Emacs =PATH= and =exec-path=
+4. Tells you what to add to your agent instructions file
 
 * Startup wrapper
 
 By default, =meta-agent-shell= uses its own wrapper ~meta-agent-shell-default-start-function~
 to establish the expected behavior when starting meta sessions, dispatchers, and named agents.
 
-It accepts these call patterns:
+For most custom behavior, keep the package-owned wrapper and use
+~meta-agent-shell-before-start-hook~ or ~meta-agent-shell-after-start-hook~.
 
-- no prefix: normal mode, project/git-root directory
-- ~C-u~: container mode, project/git-root directory
-- ~C-u C-u~: container mode, current buffer directory
-- internal ~'use-current-dir~: normal mode, current buffer directory
+The wrapper binds dynamic context variables:
 
-Container mode does nothing by default but allows for additional configuration.
+| Name                                            | Description                                                                                                                                    |
+|-------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------|
+| ~meta-agent-shell-start-context~                | Package-managed start context, typically ~meta~, ~dispatcher~, or ~named-agent~.                                                               |
+| ~meta-agent-shell-start-directory~              | Directory the session will start in; the wrapper binds ~default-directory~ to this value before calling ~agent-shell-start~.                   |
+| ~meta-agent-shell-start-buffer-name~            | Optional buffer name override inserted into the resolved ~agent-shell~ config before startup.                                                  |
+| ~meta-agent-shell-start-session-policy~         | Abstract startup policy, ~safe~ or ~aggressive~, translated through ~meta-agent-shell-session-mode-map~ into a provider-specific session mode. |
+| ~meta-agent-shell-start-command-prefix~         | Optional command prefix to install for the new session, for example ~claudebox --bash -c~.                                                     |
+| ~meta-agent-shell-start-path-resolver-function~ | Optional path resolver function installed for the new session buffer.                                                                          |
+| ~meta-agent-shell-start-config~                 | Base ~agent-shell~ config selected by the wrapper; hooks can replace or adjust it before buffer-name and session-policy overrides are applied. |
 
-The ~'use-current-dir~ input is for package-internal programmatic starts such as
-named agents; users normally use the prefix forms above.
-
-** Minimal customization
-
-Use =agent-shell= config selection for the base agent, and customize the
-two package-owned extension points when needed:
+** Customization example
 
 #+begin_src elisp
-(use-package meta-agent-shell
-  :after agent-shell
-  :config
-  (setq agent-shell-preferred-agent-config 'claude-code)
-
-  ;; Optional: define what container mode means on your machine.
-  (setq meta-agent-shell-container-mode-settings
-        '(:command-prefix ("claudebox" "--bash" "-c")
-          :path-resolver-function agent-shell--resolve-devcontainer-path))
-
-  ;; Optional: force safe startup policy in specific directories.
-  ;; For Claude Code, safe maps to the provider's "default" mode.
-  (setq meta-agent-shell-safe-directory-prefixes
-        '("~/code/secretary")))
+(add-hook
+ 'meta-agent-shell-before-start-hook
+ (defun my/meta-agent-shell-start-customizations ()
+   (pcase meta-agent-shell-start-context
+     ('dispatcher
+      (setq meta-agent-shell-start-session-policy 'safe))
+     ('named-agent
+      (when (string-match-p "/secretary/" meta-agent-shell-start-directory)
+        (setq meta-agent-shell-start-session-policy 'safe)
+        (setq meta-agent-shell-start-command-prefix
+              '("claudebox" "--bash" "-c"))
+        (setq meta-agent-shell-start-path-resolver-function
+              #'agent-shell--resolve-devcontainer-path)))
+     ('meta
+      (setq meta-agent-shell-start-buffer-name "Meta Claude")))))
 #+end_src
 
-Safe-directory overrides apply regardless of prefix arg.  Prefixes control
-container/current-directory behavior; policy controls provider-specific session
-mode selection (aggressive vs. safe).
-
-`meta-agent-shell-session-policy-function' can override the package's
-`safe' vs `aggressive' policy decision directly.
-
-Prefix args apply to start commands: ~C-u~ selects container + project root,
-and ~C-u C-u~ selects container + current buffer directory.
+~meta-agent-shell-start-function~ also allows one to replace the wrapper entirely.
 
 | Keybinding  | Command                               | Description                       |
 |-------------+---------------------------------------+-----------------------------------|

--- a/README.org
+++ b/README.org
@@ -48,11 +48,12 @@ the non-Elisp files this repo needs (=bin/=, =agent-overview.md=, =meta-claude.m
 A Quelpa example of including the non-Elisp files:
 
 #+begin_src elisp
-:files (:defaults
-        ("bin" "bin/*")
-        "agent-overview.md"
-        "meta-claude.md"
-        "shared-tools.md")
+  :files (:defaults
+          ("bin" "bin/*")
+          "agent-overview.md"
+          "meta-claude.md"
+          "shared-tools.md"
+          "dispatcher-instructions.md")
 #+end_src
 
 Then run:
@@ -82,10 +83,11 @@ The wrapper binds dynamic context variables:
 | ~meta-agent-shell-start-context~                | Package-managed start context, typically ~meta~, ~dispatcher~, or ~named-agent~.                                                               |
 | ~meta-agent-shell-start-directory~              | Directory the session will start in; the wrapper binds ~default-directory~ to this value before calling ~agent-shell-start~.                   |
 | ~meta-agent-shell-start-buffer-name~            | Optional buffer name override inserted into the resolved ~agent-shell~ config before startup.                                                  |
-| ~meta-agent-shell-start-session-policy~         | Abstract startup policy, ~safe~ or ~aggressive~, translated through ~meta-agent-shell-session-mode-map~ into a provider-specific session mode. |
+| ~meta-agent-shell-start-session-policy~         | Abstract startup policy, ~safe~, ~auto~ (default), or ~aggressive~. Translated through ~meta-agent-shell-session-mode-map~ for equivalent behavior across models. |
+| ~meta-agent-shell-start-session-mode-id~        | Optional provider mode id override. When non-nil, this takes precedence over ~meta-agent-shell-start-session-policy~ and is passed through directly. |
 | ~meta-agent-shell-start-command-prefix~         | Optional command prefix to install for the new session, for example ~claudebox --bash -c~.                                                     |
 | ~meta-agent-shell-start-path-resolver-function~ | Optional path resolver function installed for the new session buffer.                                                                          |
-| ~meta-agent-shell-start-config~                 | Base ~agent-shell~ config selected by the wrapper; hooks can replace or adjust it before buffer-name and session-policy overrides are applied. |
+| ~meta-agent-shell-start-config~                 | Base ~agent-shell~ config selected by the wrapper; hooks can replace or adjust it before buffer-name and session mode overrides are applied. |
 
 ** Customization example
 
@@ -94,17 +96,24 @@ The wrapper binds dynamic context variables:
  'meta-agent-shell-before-start-hook
  (defun my/meta-agent-shell-start-customizations ()
    (pcase meta-agent-shell-start-context
-     ('dispatcher
-      (setq meta-agent-shell-start-session-policy 'safe))
      ('named-agent
       (when (string-match-p "/secretary/" meta-agent-shell-start-directory)
         (setq meta-agent-shell-start-session-policy 'safe)
         (setq meta-agent-shell-start-command-prefix
               '("claudebox" "--bash" "-c"))
         (setq meta-agent-shell-start-path-resolver-function
-              #'agent-shell--resolve-devcontainer-path)))
+              #'agent-shell--resolve-devcontainer-path))
+      (when current-prefix-arg
+        (setq meta-agent-shell-start-session-mode-id 'plan)))
      ('meta
       (setq meta-agent-shell-start-buffer-name "Meta Claude")))))
+
+(add-hook
+ 'meta-agent-shell-after-start-hook
+ (defun my/meta-agent-shell-dispatcher-bootstrap ()
+   (when (eq meta-agent-shell-start-context 'dispatcher)
+     (shell-maker-submit
+      :input "Read ~/.policies/policy.org for inter-agent policies."))))
 #+end_src
 
 ~meta-agent-shell-start-function~ also allows one to replace the wrapper entirely.

--- a/README.org
+++ b/README.org
@@ -22,23 +22,13 @@ Plus:
 
 * Setup
 
-#+begin_src bash
-./setup.sh
-#+end_src
-
-This:
-1. Creates =~/.claude-meta/= directory
-2. Links the meta-agent CLAUDE.md
-3. Tells you what to add to your shell config and =~/.claude/CLAUDE.md=
-
-Then add to your Emacs config:
+Add to your Emacs config:
 
 #+begin_src elisp
 (use-package meta-agent-shell
   :after agent-shell
   :config
   (setq meta-agent-shell-heartbeat-file "~/heartbeat.org")
-  (setq meta-agent-shell-start-function #'agent-shell)  ; or your custom start function
 
   ;; Recommended keybindings under SPC o m
   ;; Unbind existing SPC o m (mu4e in Doom) first if needed
@@ -53,14 +43,69 @@ Then add to your Emacs config:
          :desc "STOP ALL AGENTS" "!" #'meta-agent-shell-big-red-button)))
 #+end_src
 
-| Keybinding  | Command                              | Description                     |
-|-------------+--------------------------------------+---------------------------------|
-| =SPC o m m= | ~meta-agent-shell-start~             | Meta-agent session (start/switch) |
+Then run:
+
+#+begin_example
+M-x meta-agent-shell-setup
+#+end_example
+
+* Startup wrapper
+
+By default, =meta-agent-shell= uses its own wrapper ~meta-agent-shell-default-start-function~
+to establish the expected behavior when starting meta sessions, dispatchers, and named agents.
+
+It accepts these call patterns:
+
+- no prefix: normal mode, project/git-root directory
+- ~C-u~: container mode, project/git-root directory
+- ~C-u C-u~: container mode, current buffer directory
+- internal ~'use-current-dir~: normal mode, current buffer directory
+
+Container mode does nothing by default but allows for additional configuration.
+
+The ~'use-current-dir~ input is for package-internal programmatic starts such as
+named agents; users normally use the prefix forms above.
+
+** Minimal customization
+
+Use =agent-shell= config selection for the base agent, and customize the
+two package-owned extension points when needed:
+
+#+begin_src elisp
+(use-package meta-agent-shell
+  :after agent-shell
+  :config
+  (setq agent-shell-preferred-agent-config 'claude-code)
+
+  ;; Optional: define what container mode means on your machine.
+  (setq meta-agent-shell-container-mode-settings
+        '(:command-prefix ("claudebox" "--bash" "-c")
+          :path-resolver-function agent-shell--resolve-devcontainer-path))
+
+  ;; Optional: force safe startup policy in specific directories.
+  ;; For Claude Code, safe maps to the provider's "default" mode.
+  (setq meta-agent-shell-safe-directory-prefixes
+        '("~/code/secretary")))
+#+end_src
+
+Safe-directory overrides apply regardless of prefix arg.  Prefixes control
+container/current-directory behavior; policy controls provider-specific session
+mode selection (aggressive vs. safe).
+
+`meta-agent-shell-session-policy-function' can override the package's
+`safe' vs `aggressive' policy decision directly.
+
+Prefix args apply to start commands: ~C-u~ selects container + project root,
+and ~C-u C-u~ selects container + current buffer directory.
+
+| Keybinding  | Command                               | Description                       |
+|-------------+---------------------------------------+-----------------------------------|
+| =SPC o m m= | ~meta-agent-shell-start~              | Meta-agent session (start/switch) |
 | =SPC o m d= | ~meta-agent-shell-jump-to-dispatcher~ | Project dispatcher (start/switch) |
-| =SPC o m h= | ~meta-agent-shell-heartbeat-start~   | Start heartbeat timer           |
-| =SPC o m H= | ~meta-agent-shell-heartbeat-stop~    | Stop heartbeat timer            |
-| =SPC o m s= | ~meta-agent-shell-heartbeat-send-now~ | Send heartbeat immediately      |
-| =SPC o m != | ~meta-agent-shell-big-red-button~    | STOP ALL AGENTS                 |
+| =SPC o m h= | ~meta-agent-shell-heartbeat-start~    | Start heartbeat timer             |
+| =SPC o m H= | ~meta-agent-shell-heartbeat-stop~     | Stop heartbeat timer              |
+| =SPC o m s= | ~meta-agent-shell-heartbeat-send-now~ | Send heartbeat immediately        |
+| =SPC o m != | ~meta-agent-shell-big-red-button~     | STOP ALL AGENTS                   |
 
 * Workflow 1: Project Dispatchers
 

--- a/README.org
+++ b/README.org
@@ -49,6 +49,11 @@ Then run:
 M-x meta-agent-shell-setup
 #+end_example
 
+This:
+1. Creates =~/.claude-meta/= directory
+2. Links the meta-agent CLAUDE.md
+3. Tells you what to add to your shell config and =~/.claude/CLAUDE.md=
+
 * Startup wrapper
 
 By default, =meta-agent-shell= uses its own wrapper ~meta-agent-shell-default-start-function~

--- a/README.org
+++ b/README.org
@@ -83,7 +83,7 @@ The wrapper binds dynamic context variables:
 | ~meta-agent-shell-start-context~                | Package-managed start context, typically ~meta~, ~dispatcher~, or ~named-agent~.                                                               |
 | ~meta-agent-shell-start-directory~              | Directory the session will start in; the wrapper binds ~default-directory~ to this value before calling ~agent-shell-start~.                   |
 | ~meta-agent-shell-start-buffer-name~            | Optional buffer name override inserted into the resolved ~agent-shell~ config before startup.                                                  |
-| ~meta-agent-shell-start-session-policy~         | Abstract startup policy, ~safe~, ~auto~ (default), or ~aggressive~. Translated through ~meta-agent-shell-session-mode-map~ for equivalent behavior across models. |
+| ~meta-agent-shell-start-session-policy~         | Abstract startup policy, ~safe~, ~auto~ (default), or ~aggressive~. Translated through ~meta-agent-shell-session-mode-map~ for equivalent behavior across agents. |
 | ~meta-agent-shell-start-session-mode-id~        | Optional provider mode id override. When non-nil, this takes precedence over ~meta-agent-shell-start-session-policy~ and is passed through directly. |
 | ~meta-agent-shell-start-command-prefix~         | Optional command prefix to install for the new session, for example ~claudebox --bash -c~.                                                     |
 | ~meta-agent-shell-start-path-resolver-function~ | Optional path resolver function installed for the new session buffer.                                                                          |

--- a/README.org
+++ b/README.org
@@ -22,7 +22,9 @@ Plus:
 
 * Setup
 
-Add to your Emacs config:
+First install =meta-agent-shell= from a local checkout or package recipe that includes
+the non-Elisp files this repo needs (=bin/=, =agent-overview.md=, =meta-claude.md=,
+=shared-tools.md=). Then add this to your Emacs config:
 
 #+begin_src elisp
 (use-package meta-agent-shell
@@ -41,6 +43,16 @@ Add to your Emacs config:
          :desc "Stop heartbeat" "H" #'meta-agent-shell-heartbeat-stop
          :desc "Send heartbeat now" "s" #'meta-agent-shell-heartbeat-send-now
          :desc "STOP ALL AGENTS" "!" #'meta-agent-shell-big-red-button)))
+#+end_src
+
+A Quelpa example of including the non-Elisp files:
+
+#+begin_src elisp
+:files (:defaults
+        ("bin" "bin/*")
+        "agent-overview.md"
+        "meta-claude.md"
+        "shared-tools.md")
 #+end_src
 
 Then run:

--- a/meta-agent-shell-test.el
+++ b/meta-agent-shell-test.el
@@ -101,6 +101,29 @@
 (defvar meta-agent-shell-test--temp-dirs nil
   "List of temp directories created during tests.")
 
+(defvar meta-agent-shell-test--captured-start-context nil
+  "Captured value of `meta-agent-shell-start-context' during tests.")
+
+(defvar meta-agent-shell-test--captured-start-directory nil
+  "Captured value of `meta-agent-shell-start-directory' during tests.")
+
+(defvar meta-agent-shell-test--captured-start-buffer-name nil
+  "Captured value of `meta-agent-shell-start-buffer-name' during tests.")
+
+(defvar meta-agent-shell-test--captured-after-start-buffer nil
+  "Captured buffer from `meta-agent-shell-after-start-hook' during tests.")
+
+(defun meta-agent-shell-test--capture-start-context ()
+  "Record the current dynamic start variables."
+  (setq meta-agent-shell-test--captured-start-context meta-agent-shell-start-context
+        meta-agent-shell-test--captured-start-directory meta-agent-shell-start-directory
+        meta-agent-shell-test--captured-start-buffer-name meta-agent-shell-start-buffer-name))
+
+(defun meta-agent-shell-test--capture-after-start-buffer ()
+  "Record the buffer seen by `meta-agent-shell-after-start-hook'."
+  (setq meta-agent-shell-test--captured-after-start-buffer (current-buffer))
+  (meta-agent-shell-test--capture-start-context))
+
 (defmacro meta-agent-shell-test--with-clean-state (&rest body)
   "Execute BODY with fresh meta-agent-shell state."
   (declare (indent 0))
@@ -110,6 +133,19 @@
          (meta-agent-shell--dispatchers nil)
          (meta-agent-shell--allowed-targets nil)
          (meta-agent-shell-restrict-targets nil)
+         (meta-agent-shell-before-start-hook nil)
+         (meta-agent-shell-after-start-hook nil)
+         (meta-agent-shell-start-context nil)
+         (meta-agent-shell-start-directory nil)
+         (meta-agent-shell-start-buffer-name nil)
+         (meta-agent-shell-start-session-policy nil)
+         (meta-agent-shell-start-command-prefix nil)
+         (meta-agent-shell-start-path-resolver-function nil)
+         (meta-agent-shell-start-config nil)
+         (meta-agent-shell-test--captured-start-context nil)
+         (meta-agent-shell-test--captured-start-directory nil)
+         (meta-agent-shell-test--captured-start-buffer-name nil)
+         (meta-agent-shell-test--captured-after-start-buffer nil)
          (meta-agent-shell-test--agent-shell-start-calls nil)
          (meta-agent-shell-test--agent-shell-config
           '((:identifier . test-agent)
@@ -597,13 +633,15 @@ Optional PROJECT-PATH sets the default-directory."
                 (buffer-string))))
      (with-current-buffer "*meta-agent-shell setup*"
        (should (string-match-p
-                (regexp-quote (format "export PATH=\"%s/bin:$PATH\"" support-dir))
+                (regexp-quote
+                 (format "meta-agent-shell will add its support script directory %s/bin to Emacs PATH and exec-path automatically."
+                         support-dir))
                 (buffer-string)))
        (should (string-match-p
                 (regexp-quote (format "@%s" support-overview))
                 (buffer-string)))
        (should (string-match-p
-                (regexp-quote "~/.claude/CLAUDE.md")
+                (regexp-quote "~/.codex/AGENTS.md or ~/.claude/CLAUDE.md")
                 (buffer-string)))))))
 
 (ert-deftest meta-agent-shell-test-setup-is-idempotent-and-removes-legacy-symlink ()
@@ -661,38 +699,44 @@ Optional PROJECT-PATH sets the default-directory."
      (let ((call (car meta-agent-shell-test--agent-shell-start-calls)))
        (should (equal "/tmp/current-dir/" (plist-get call :cwd-function-value)))))))
 
-(ert-deftest meta-agent-shell-test-default-start-function-container-mode-settings ()
-  "Test container-mode settings are applied in container branches only."
+(ert-deftest meta-agent-shell-test-default-start-function-before-start-hook-command-overrides ()
+  "Test `meta-agent-shell-before-start-hook' can set command overrides."
   (meta-agent-shell-test--with-clean-state
-   (let ((meta-agent-shell-container-mode-settings
-          '(:command-prefix ("claudebox" "--bash" "-c")
-                            :path-resolver-function identity)))
-     (meta-agent-shell-default-start-function '(4) "Worker")
+   (let ((meta-agent-shell-before-start-hook
+          (list (lambda ()
+                  (setq meta-agent-shell-start-command-prefix
+                        '("claudebox" "--bash" "-c")
+                        meta-agent-shell-start-path-resolver-function #'identity)))))
+     (meta-agent-shell-default-start-function nil "Worker")
      (let ((call (car meta-agent-shell-test--agent-shell-start-calls)))
        (should (equal '("claudebox" "--bash" "-c")
                       (plist-get call :command-prefix)))
-       (should (eq #'identity (plist-get call :path-resolver-function))))
-     (setq meta-agent-shell-test--agent-shell-start-calls nil)
-     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
-     (let ((call (car meta-agent-shell-test--agent-shell-start-calls)))
-       (should-not (plist-get call :command-prefix))
-       (should-not (plist-get call :path-resolver-function))))))
+       (should (eq #'identity (plist-get call :path-resolver-function)))))))
 
-(ert-deftest meta-agent-shell-test-default-start-function-session-policy-override ()
-  "Test session policy override can force safe mode without replacing the wrapper."
+(ert-deftest meta-agent-shell-test-default-start-function-session-policy-translation ()
+  "Test session policy translation uses `meta-agent-shell-session-mode-map'."
   (meta-agent-shell-test--with-clean-state
    (let ((meta-agent-shell-test--agent-shell-config
           '((:identifier . claude-code)
             (:buffer-name . "Claude Code")))
-         (meta-agent-shell-session-policy-function
-          (lambda (_config _use-container _use-current-dir _directory)
-            'safe))
+         (meta-agent-shell-before-start-hook
+          (list (lambda ()
+                  (setq meta-agent-shell-start-session-policy 'safe))))
          (default-directory "/tmp/normal-project/"))
      (meta-agent-shell-default-start-function 'use-current-dir "Worker")
      (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
             (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
        (should (functionp mode-id-fn))
        (should (equal "default" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-after-start-hook-runs-in-started-buffer ()
+  "Test `meta-agent-shell-after-start-hook' runs in the started buffer."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-after-start-hook
+          '(meta-agent-shell-test--capture-after-start-buffer)))
+     (let ((buf (meta-agent-shell-default-start-function nil "Worker")))
+       (should (eq buf meta-agent-shell-test--captured-after-start-buffer))
+       (should (equal "Worker" meta-agent-shell-test--captured-start-buffer-name))))))
 
 (ert-deftest meta-agent-shell-test-default-start-function-preserves-provider-mode-default ()
   "Test provider-defined session mode defaults are preserved by default."
@@ -708,33 +752,53 @@ Optional PROJECT-PATH sets the default-directory."
        (should (functionp mode-id-fn))
        (should (equal "full-access" (funcall mode-id-fn)))))))
 
-(ert-deftest meta-agent-shell-test-default-start-function-safe-directory-overrides-provider-default ()
-  "Test safe-directory policy overrides provider-defined aggressive defaults."
-  (meta-agent-shell-test--with-clean-state
-   (let ((meta-agent-shell-test--agent-shell-config
-          '((:identifier . codex)
-            (:buffer-name . "Codex")
-            (:default-session-mode-id . (lambda () "full-access"))))
-         (meta-agent-shell-safe-directory-prefixes '("/tmp/safe-root"))
-         (default-directory "/tmp/safe-root/project/"))
-     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
-     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
-            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
-       (should (functionp mode-id-fn))
-       (should (equal "auto" (funcall mode-id-fn)))))))
-
-(ert-deftest meta-agent-shell-test-default-start-function-codex-aggressive-mode ()
-  "Test Codex uses the mapped aggressive mode id by default."
+(ert-deftest meta-agent-shell-test-default-start-function-does-not-inject-mode-without-policy ()
+  "Test the wrapper leaves mode selection alone when no policy is supplied."
   (meta-agent-shell-test--with-clean-state
    (let ((meta-agent-shell-test--agent-shell-config
           '((:identifier . codex)
             (:buffer-name . "Codex")))
          (default-directory "/tmp/normal-project/"))
      (meta-agent-shell-default-start-function 'use-current-dir "Worker")
-     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
-            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
-       (should (functionp mode-id-fn))
-       (should (equal "full-access" (funcall mode-id-fn)))))))
+     (let ((call (car meta-agent-shell-test--agent-shell-start-calls)))
+       (should-not (map-elt (plist-get call :config) :default-session-mode-id))))))
+
+(ert-deftest meta-agent-shell-test-start-named-agent-binds-start-context ()
+  "Test named-agent startup binds `meta-agent-shell-start-context'."
+  (meta-agent-shell-test--with-clean-state
+   (let ((project-dir (meta-agent-shell-test--create-temp-dir))
+         (meta-agent-shell-start-function #'meta-agent-shell-default-start-function)
+         (meta-agent-shell-before-start-hook
+          '(meta-agent-shell-test--capture-start-context)))
+     (meta-agent-shell-start-named-agent project-dir "Worker")
+     (should (eq 'named-agent meta-agent-shell-test--captured-start-context))
+     (should (equal project-dir meta-agent-shell-test--captured-start-directory))
+     (should (equal "Worker" meta-agent-shell-test--captured-start-buffer-name)))))
+
+(ert-deftest meta-agent-shell-test-start-dispatcher-binds-start-context ()
+  "Test dispatcher startup binds `meta-agent-shell-start-context'."
+  (meta-agent-shell-test--with-clean-state
+   (let ((project-dir (meta-agent-shell-test--create-temp-dir))
+         (meta-agent-shell-start-function #'meta-agent-shell-default-start-function)
+         (meta-agent-shell-before-start-hook
+          '(meta-agent-shell-test--capture-start-context)))
+     (meta-agent-shell-start-dispatcher project-dir)
+     (should (eq 'dispatcher meta-agent-shell-test--captured-start-context))
+     (should (equal project-dir meta-agent-shell-test--captured-start-directory))
+     (should (equal "Dispatcher" meta-agent-shell-test--captured-start-buffer-name)))))
+
+(ert-deftest meta-agent-shell-test-start-meta-binds-start-context ()
+  "Test meta startup binds `meta-agent-shell-start-context'."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-directory
+          (file-name-as-directory (meta-agent-shell-test--create-temp-dir)))
+         (meta-agent-shell-start-function #'meta-agent-shell-default-start-function)
+         (meta-agent-shell-before-start-hook
+          '(meta-agent-shell-test--capture-start-context)))
+     (meta-agent-shell-start)
+     (should (eq 'meta meta-agent-shell-test--captured-start-context))
+     (should (equal (expand-file-name meta-agent-shell-directory)
+                    meta-agent-shell-test--captured-start-directory)))))
 
 (ert-deftest meta-agent-shell-test-start-named-agent-uses-actual-buffer-name ()
   "Test named-agent bookkeeping uses the actual created buffer name."

--- a/meta-agent-shell-test.el
+++ b/meta-agent-shell-test.el
@@ -110,6 +110,12 @@
 (defvar meta-agent-shell-test--captured-start-buffer-name nil
   "Captured value of `meta-agent-shell-start-buffer-name' during tests.")
 
+(defvar meta-agent-shell-test--captured-start-session-policy nil
+  "Captured value of `meta-agent-shell-start-session-policy' during tests.")
+
+(defvar meta-agent-shell-test--captured-start-session-mode-id nil
+  "Captured value of `meta-agent-shell-start-session-mode-id' during tests.")
+
 (defvar meta-agent-shell-test--captured-after-start-buffer nil
   "Captured buffer from `meta-agent-shell-after-start-hook' during tests.")
 
@@ -117,7 +123,9 @@
   "Record the current dynamic start variables."
   (setq meta-agent-shell-test--captured-start-context meta-agent-shell-start-context
         meta-agent-shell-test--captured-start-directory meta-agent-shell-start-directory
-        meta-agent-shell-test--captured-start-buffer-name meta-agent-shell-start-buffer-name))
+        meta-agent-shell-test--captured-start-buffer-name meta-agent-shell-start-buffer-name
+        meta-agent-shell-test--captured-start-session-policy meta-agent-shell-start-session-policy
+        meta-agent-shell-test--captured-start-session-mode-id meta-agent-shell-start-session-mode-id))
 
 (defun meta-agent-shell-test--capture-after-start-buffer ()
   "Record the buffer seen by `meta-agent-shell-after-start-hook'."
@@ -139,12 +147,15 @@
          (meta-agent-shell-start-directory nil)
          (meta-agent-shell-start-buffer-name nil)
          (meta-agent-shell-start-session-policy nil)
+         (meta-agent-shell-start-session-mode-id nil)
          (meta-agent-shell-start-command-prefix nil)
          (meta-agent-shell-start-path-resolver-function nil)
          (meta-agent-shell-start-config nil)
          (meta-agent-shell-test--captured-start-context nil)
          (meta-agent-shell-test--captured-start-directory nil)
          (meta-agent-shell-test--captured-start-buffer-name nil)
+         (meta-agent-shell-test--captured-start-session-policy nil)
+         (meta-agent-shell-test--captured-start-session-mode-id nil)
          (meta-agent-shell-test--captured-after-start-buffer nil)
          (meta-agent-shell-test--agent-shell-start-calls nil)
          (meta-agent-shell-test--agent-shell-config
@@ -727,7 +738,15 @@ Optional PROJECT-PATH sets the default-directory."
      (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
             (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
        (should (functionp mode-id-fn))
-       (should (equal "default" (funcall mode-id-fn)))))))
+       (should (equal "dontAsk" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-before-start-hook-sees-auto-policy-default ()
+  "Test hooks see the package-managed `auto' policy before overrides."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-before-start-hook
+          '(meta-agent-shell-test--capture-start-context)))
+     (meta-agent-shell-default-start-function nil "Worker")
+     (should (eq 'auto meta-agent-shell-test--captured-start-session-policy)))))
 
 (ert-deftest meta-agent-shell-test-default-start-function-after-start-hook-runs-in-started-buffer ()
   "Test `meta-agent-shell-after-start-hook' runs in the started buffer."
@@ -738,30 +757,52 @@ Optional PROJECT-PATH sets the default-directory."
        (should (eq buf meta-agent-shell-test--captured-after-start-buffer))
        (should (equal "Worker" meta-agent-shell-test--captured-start-buffer-name))))))
 
-(ert-deftest meta-agent-shell-test-default-start-function-preserves-provider-mode-default ()
-  "Test provider-defined session mode defaults are preserved by default."
-  (meta-agent-shell-test--with-clean-state
-   (let ((meta-agent-shell-test--agent-shell-config
-          '((:identifier . codex)
-            (:buffer-name . "Codex")
-            (:default-session-mode-id . (lambda () "full-access"))))
-         (default-directory "/tmp/normal-project/"))
-     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
-     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
-            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
-       (should (functionp mode-id-fn))
-       (should (equal "full-access" (funcall mode-id-fn)))))))
-
-(ert-deftest meta-agent-shell-test-default-start-function-does-not-inject-mode-without-policy ()
-  "Test the wrapper leaves mode selection alone when no policy is supplied."
+(ert-deftest meta-agent-shell-test-default-start-function-uses-auto-policy-by-default ()
+  "Test package-managed starts default to the abstract `auto' policy."
   (meta-agent-shell-test--with-clean-state
    (let ((meta-agent-shell-test--agent-shell-config
           '((:identifier . codex)
             (:buffer-name . "Codex")))
          (default-directory "/tmp/normal-project/"))
      (meta-agent-shell-default-start-function 'use-current-dir "Worker")
-     (let ((call (car meta-agent-shell-test--agent-shell-start-calls)))
-       (should-not (map-elt (plist-get call :config) :default-session-mode-id))))))
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (functionp mode-id-fn))
+       (should (equal "auto" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-explicit-mode-id-overrides-policy ()
+  "Test explicit raw mode ids take precedence over abstract policy mapping."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-test--agent-shell-config
+          '((:identifier . claude-code)
+            (:buffer-name . "Claude Code")))
+         (meta-agent-shell-before-start-hook
+          (list (lambda ()
+                  (setq meta-agent-shell-start-session-policy 'safe
+                        meta-agent-shell-start-session-mode-id 'plan))))
+         (default-directory "/tmp/normal-project/"))
+     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (functionp mode-id-fn))
+       (should (equal "plan" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-preserves-provider-mode-default-when-policy-disabled ()
+  "Test hooks can disable the abstract policy and keep the provider default."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-test--agent-shell-config
+          '((:identifier . codex)
+            (:buffer-name . "Codex")
+            (:default-session-mode-id . (lambda () "full-access"))))
+         (meta-agent-shell-before-start-hook
+          (list (lambda ()
+                  (setq meta-agent-shell-start-session-policy nil))))
+         (default-directory "/tmp/normal-project/"))
+     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (functionp mode-id-fn))
+       (should (equal "full-access" (funcall mode-id-fn)))))))
 
 (ert-deftest meta-agent-shell-test-start-named-agent-binds-start-context ()
   "Test named-agent startup binds `meta-agent-shell-start-context'."

--- a/meta-agent-shell-test.el
+++ b/meta-agent-shell-test.el
@@ -54,7 +54,7 @@
         (setq-local default-directory (or cwd-value "/tmp/test-project/"))
         (setq-local agent-shell--state
                     `(:agent-config ,config
-                      :outgoing-request-decorator ,outgoing-request-decorator)))
+                                    :outgoing-request-decorator ,outgoing-request-decorator)))
       buf))
   (defun agent-shell-get-config (_buffer)
     "Stub for current buffer config lookup."
@@ -142,7 +142,7 @@ Optional PROJECT-PATH sets the default-directory."
       ;; Mock agent-shell--state for status detection
       (setq-local agent-shell--state
                   '(:client (:process nil)
-                    :session (:mode-id "code"))))
+                            :session (:mode-id "code"))))
     (push buf meta-agent-shell-test--mock-buffers)
     buf))
 
@@ -666,7 +666,7 @@ Optional PROJECT-PATH sets the default-directory."
   (meta-agent-shell-test--with-clean-state
    (let ((meta-agent-shell-container-mode-settings
           '(:command-prefix ("claudebox" "--bash" "-c")
-            :path-resolver-function identity)))
+                            :path-resolver-function identity)))
      (meta-agent-shell-default-start-function '(4) "Worker")
      (let ((call (car meta-agent-shell-test--agent-shell-start-calls)))
        (should (equal '("claudebox" "--bash" "-c")
@@ -693,6 +693,35 @@ Optional PROJECT-PATH sets the default-directory."
             (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
        (should (functionp mode-id-fn))
        (should (equal "default" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-preserves-provider-mode-default ()
+  "Test provider-defined session mode defaults are preserved by default."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-test--agent-shell-config
+          '((:identifier . codex)
+            (:buffer-name . "Codex")
+            (:default-session-mode-id . (lambda () "full-access"))))
+         (default-directory "/tmp/normal-project/"))
+     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (functionp mode-id-fn))
+       (should (equal "full-access" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-safe-directory-overrides-provider-default ()
+  "Test safe-directory policy overrides provider-defined aggressive defaults."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-test--agent-shell-config
+          '((:identifier . codex)
+            (:buffer-name . "Codex")
+            (:default-session-mode-id . (lambda () "full-access"))))
+         (meta-agent-shell-safe-directory-prefixes '("/tmp/safe-root"))
+         (default-directory "/tmp/safe-root/project/"))
+     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (functionp mode-id-fn))
+       (should (equal "auto" (funcall mode-id-fn)))))))
 
 (ert-deftest meta-agent-shell-test-default-start-function-codex-aggressive-mode ()
   "Test Codex uses the mapped aggressive mode id by default."

--- a/meta-agent-shell-test.el
+++ b/meta-agent-shell-test.el
@@ -18,13 +18,54 @@
 (require 'cl-lib)
 (require 'json)
 
+(defvar meta-agent-shell-test--agent-shell-start-calls nil
+  "Recorded calls to `agent-shell-start' during tests.")
+
+(defvar meta-agent-shell-test--agent-shell-config
+  '((:identifier . test-agent)
+    (:buffer-name . "Test Agent"))
+  "Mock config returned by `agent-shell' config helpers.")
+
 ;; Stub dependencies before loading meta-agent-shell
 ;; These provide minimal definitions so the file can load in batch mode
 (unless (featurep 'agent-shell)
   (provide 'agent-shell)
-  (defun agent-shell (&optional _prefix _buffer-name)
+  (define-derived-mode agent-shell-mode fundamental-mode "Agent-Shell")
+  (defvar agent-shell-cwd-function nil)
+  (defvar agent-shell-command-prefix nil)
+  (defvar agent-shell-path-resolver-function nil)
+  (defun agent-shell (&optional _arg)
     "Stub for agent-shell."
     (get-buffer-create "*agent-shell*"))
+  (cl-defun agent-shell-start (&key config outgoing-request-decorator)
+    "Stub for programmatic agent-shell startup."
+    (let* ((cwd-value (and agent-shell-cwd-function
+                           (funcall agent-shell-cwd-function)))
+           (call (list :config config
+                       :outgoing-request-decorator outgoing-request-decorator
+                       :cwd-function-value cwd-value
+                       :command-prefix agent-shell-command-prefix
+                       :path-resolver-function agent-shell-path-resolver-function))
+           (display-name (or (map-elt config :buffer-name) "Agent"))
+           (buf (get-buffer-create (format "%s Agent @ test-project" display-name))))
+      (push call meta-agent-shell-test--agent-shell-start-calls)
+      (with-current-buffer buf
+        (agent-shell-mode)
+        (setq-local default-directory (or cwd-value "/tmp/test-project/"))
+        (setq-local agent-shell--state
+                    `(:agent-config ,config
+                      :outgoing-request-decorator ,outgoing-request-decorator)))
+      buf))
+  (defun agent-shell-get-config (_buffer)
+    "Stub for current buffer config lookup."
+    meta-agent-shell-test--agent-shell-config)
+  (defun agent-shell--resolve-preferred-config ()
+    "Stub for preferred config lookup."
+    meta-agent-shell-test--agent-shell-config)
+  (cl-defun agent-shell-select-config (&key prompt)
+    "Stub for interactive config selection."
+    (ignore prompt)
+    meta-agent-shell-test--agent-shell-config)
   (defun agent-shell-buffers ()
     "Stub returning empty list."
     nil)
@@ -57,6 +98,9 @@
 (defvar meta-agent-shell-test--temp-files nil
   "List of temp files created during tests.")
 
+(defvar meta-agent-shell-test--temp-dirs nil
+  "List of temp directories created during tests.")
+
 (defmacro meta-agent-shell-test--with-clean-state (&rest body)
   "Execute BODY with fresh meta-agent-shell state."
   (declare (indent 0))
@@ -66,9 +110,14 @@
          (meta-agent-shell--dispatchers nil)
          (meta-agent-shell--allowed-targets nil)
          (meta-agent-shell-restrict-targets nil)
+         (meta-agent-shell-test--agent-shell-start-calls nil)
+         (meta-agent-shell-test--agent-shell-config
+          '((:identifier . test-agent)
+            (:buffer-name . "Test Agent")))
          (meta-agent-shell-test--mock-buffers nil)
          (meta-agent-shell-test--submitted-messages nil)
-         (meta-agent-shell-test--temp-files nil))
+         (meta-agent-shell-test--temp-files nil)
+         (meta-agent-shell-test--temp-dirs nil))
      (unwind-protect
          (progn ,@body)
        ;; Cleanup
@@ -77,7 +126,12 @@
            (kill-buffer buf)))
        (dolist (file meta-agent-shell-test--temp-files)
          (when (file-exists-p file)
-           (delete-file file))))))
+           (if (file-directory-p file)
+               (delete-directory file t)
+             (delete-file file))))
+       (dolist (dir meta-agent-shell-test--temp-dirs)
+         (when (file-exists-p dir)
+           (delete-directory dir t))))))
 
 (defun meta-agent-shell-test--make-mock-buffer (name &optional project-path)
   "Create a mock agent-shell buffer with NAME.
@@ -112,6 +166,12 @@ Optional PROJECT-PATH sets the default-directory."
       (insert content))
     (push file meta-agent-shell-test--temp-files)
     file))
+
+(defun meta-agent-shell-test--create-temp-dir ()
+  "Create a temp directory and track it for cleanup."
+  (let ((dir (make-temp-file "meta-agent-shell-test-" t)))
+    (push dir meta-agent-shell-test--temp-dirs)
+    dir))
 
 
 ;;; Target Restriction Tests
@@ -287,7 +347,9 @@ Optional PROJECT-PATH sets the default-directory."
 (ert-deftest meta-agent-shell-test-view-session ()
   "Test viewing session output."
   (meta-agent-shell-test--with-clean-state
-   (let ((buf (meta-agent-shell-test--make-mock-buffer "TestSession")))
+   (let* ((temp-dir (meta-agent-shell-test--create-temp-dir))
+          (meta-agent-shell-log-directory temp-dir)
+          (buf (meta-agent-shell-test--make-mock-buffer "TestSession")))
      (with-current-buffer buf
        (insert "Session output line 1\nSession output line 2\n"))
      (let ((output (meta-agent-shell-view-session "TestSession" 10)))
@@ -304,7 +366,11 @@ Optional PROJECT-PATH sets the default-directory."
   (meta-agent-shell-test--with-clean-state
    (cl-letf (((symbol-function 'agent-shell-buffers)
               #'meta-agent-shell-test--mock-agent-shell-buffers))
-     (let ((buf (meta-agent-shell-test--make-mock-buffer "ToClose")))
+     (let* ((temp-dir (meta-agent-shell-test--create-temp-dir))
+            (meta-agent-shell-log-directory temp-dir)
+            (killed-dir (meta-agent-shell-test--create-temp-dir))
+            (meta-agent-shell-killed-agents-directory killed-dir)
+            (buf (meta-agent-shell-test--make-mock-buffer "ToClose")))
        (should (buffer-live-p buf))
        (should (eq t (meta-agent-shell-close-session "ToClose")))
        (should-not (buffer-live-p buf))))))
@@ -377,7 +443,7 @@ Optional PROJECT-PATH sets the default-directory."
        (let ((msg (car meta-agent-shell-test--submitted-messages)))
          (should (string-match-p "Question from Asker" msg))
          (should (string-match-p "What is the status?" msg))
-         (should (string-match-p "agent-send" msg))
+         (should (string-match-p "agent-shell-send" msg))
          (should (string-match-p "Asker" msg)))
        (delete-directory temp-dir t)))))
 
@@ -507,6 +573,258 @@ Optional PROJECT-PATH sets the default-directory."
 
 ;;; Dispatcher Tests
 
+(ert-deftest meta-agent-shell-test-setup-creates-paths ()
+  "Test setup creates required directories, config file, and summary buffer."
+  (meta-agent-shell-test--with-clean-state
+   (let* ((base-dir (meta-agent-shell-test--create-temp-dir))
+          (meta-agent-shell-directory (expand-file-name "meta/" base-dir))
+          (meta-agent-shell-log-directory (expand-file-name "state/logs/" base-dir))
+          (meta-agent-shell-config-file (expand-file-name "state/config.org" base-dir))
+          (support-dir (directory-file-name
+                        (file-name-directory (expand-file-name meta-agent-shell-config-file))))
+          (support-bin-dir (expand-file-name "bin" support-dir))
+          (support-overview (expand-file-name "agent-overview.md" support-dir)))
+     (meta-agent-shell-setup)
+     (should (file-directory-p (expand-file-name meta-agent-shell-directory)))
+     (should (file-directory-p (expand-file-name meta-agent-shell-log-directory)))
+     (should (file-exists-p (expand-file-name meta-agent-shell-config-file)))
+     (should (file-directory-p support-bin-dir))
+     (should (file-exists-p support-overview))
+     (with-temp-buffer
+       (insert-file-contents (expand-file-name meta-agent-shell-config-file))
+       (should (string-match-p
+                (regexp-quote "# Meta-agent config - add @file references to include in the system prompt")
+                (buffer-string))))
+     (with-current-buffer "*meta-agent-shell setup*"
+       (should (string-match-p
+                (regexp-quote (format "export PATH=\"%s/bin:$PATH\"" support-dir))
+                (buffer-string)))
+       (should (string-match-p
+                (regexp-quote (format "@%s" support-overview))
+                (buffer-string)))
+       (should (string-match-p
+                (regexp-quote "~/.claude/CLAUDE.md")
+                (buffer-string)))))))
+
+(ert-deftest meta-agent-shell-test-setup-is-idempotent-and-removes-legacy-symlink ()
+  "Test setup removes only the legacy symlink and preserves existing config."
+  (meta-agent-shell-test--with-clean-state
+   (let* ((base-dir (meta-agent-shell-test--create-temp-dir))
+          (meta-agent-shell-directory (expand-file-name "meta/" base-dir))
+          (meta-agent-shell-log-directory (expand-file-name "state/logs/" base-dir))
+          (meta-agent-shell-config-file (expand-file-name "state/config.org" base-dir))
+          (legacy-claude (expand-file-name "CLAUDE.md"
+                                           (expand-file-name meta-agent-shell-directory)))
+          (support-overview (expand-file-name "agent-overview.md"
+                                              (directory-file-name
+                                               (file-name-directory
+                                                (expand-file-name meta-agent-shell-config-file)))))
+          (target-file (expand-file-name "legacy-target" base-dir))
+          (config-content "existing config\n"))
+     (make-directory (expand-file-name meta-agent-shell-directory) t)
+     (make-directory (file-name-directory (expand-file-name meta-agent-shell-config-file)) t)
+     (with-temp-file (expand-file-name meta-agent-shell-config-file)
+       (insert config-content))
+     (with-temp-file target-file
+       (insert "legacy"))
+     (push target-file meta-agent-shell-test--temp-files)
+     (make-symbolic-link target-file legacy-claude)
+     (meta-agent-shell-setup)
+     (should-not (file-exists-p legacy-claude))
+     (should (file-exists-p support-overview))
+     (with-temp-buffer
+       (insert-file-contents (expand-file-name meta-agent-shell-config-file))
+       (should (equal config-content (buffer-string))))
+     (meta-agent-shell-setup)
+     (should (file-directory-p (expand-file-name meta-agent-shell-directory)))
+     (should (file-directory-p (expand-file-name meta-agent-shell-log-directory)))
+     (with-temp-buffer
+       (insert-file-contents (expand-file-name meta-agent-shell-config-file))
+       (should (equal config-content (buffer-string)))))))
+
+(ert-deftest meta-agent-shell-test-package-directory-ignores-current-buffer-file ()
+  "Test package directory detection does not depend on the current buffer file."
+  (meta-agent-shell-test--with-clean-state
+   (with-temp-buffer
+     (setq-local buffer-file-name "/tmp/not-the-package-dir/init.el")
+     (let ((package-dir (meta-agent-shell--package-directory)))
+       (should (file-exists-p (expand-file-name "agent-overview.md" package-dir)))
+       (should (file-exists-p (expand-file-name "bin/agent-shell-list" package-dir)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-uses-agent-shell-start ()
+  "Test the default start function uses `agent-shell-start'."
+  (meta-agent-shell-test--with-clean-state
+   (let ((buf (meta-agent-shell-default-start-function nil "Worker")))
+     (should (buffer-live-p buf))
+     (should (= 1 (length meta-agent-shell-test--agent-shell-start-calls)))
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (config (plist-get call :config)))
+       (should (equal "Worker" (map-elt config :buffer-name)))
+       (should (equal :unset (or (plist-get call :cwd-function-value) :unset)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-use-current-dir-mode ()
+  "Test `use-current-dir' mode uses the bound `default-directory'."
+  (meta-agent-shell-test--with-clean-state
+   (let ((default-directory "/tmp/current-dir/"))
+     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
+     (let ((call (car meta-agent-shell-test--agent-shell-start-calls)))
+       (should (equal "/tmp/current-dir/" (plist-get call :cwd-function-value)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-container-mode-settings ()
+  "Test container-mode settings are applied in container branches only."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-container-mode-settings
+          '(:command-prefix ("claudebox" "--bash" "-c")
+            :path-resolver-function identity)))
+     (meta-agent-shell-default-start-function '(4) "Worker")
+     (let ((call (car meta-agent-shell-test--agent-shell-start-calls)))
+       (should (equal '("claudebox" "--bash" "-c")
+                      (plist-get call :command-prefix)))
+       (should (eq #'identity (plist-get call :path-resolver-function))))
+     (setq meta-agent-shell-test--agent-shell-start-calls nil)
+     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
+     (let ((call (car meta-agent-shell-test--agent-shell-start-calls)))
+       (should-not (plist-get call :command-prefix))
+       (should-not (plist-get call :path-resolver-function))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-safe-directory-policy ()
+  "Test safe directory prefixes force safe policy for Claude Code."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-test--agent-shell-config
+          '((:identifier . claude-code)
+            (:buffer-name . "Claude Code")))
+         (meta-agent-shell-safe-directory-prefixes '("/tmp/secretary")))
+     (let ((default-directory "/tmp/secretary/project/"))
+       (meta-agent-shell-default-start-function 'use-current-dir "Worker"))
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (functionp mode-id-fn))
+       (should (equal "default" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-aggressive-policy-by-default ()
+  "Test Claude Code defaults to aggressive policy outside safe directories."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-test--agent-shell-config
+          '((:identifier . claude-code)
+            (:buffer-name . "Claude Code")))
+         (default-directory "/tmp/normal-project/"))
+     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (functionp mode-id-fn))
+       (should (equal "bypassPermissions" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-session-policy-override ()
+  "Test session policy override can force safe mode without replacing the wrapper."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-test--agent-shell-config
+          '((:identifier . claude-code)
+            (:buffer-name . "Claude Code")))
+         (meta-agent-shell-session-policy-function
+          (lambda (_config _use-container _use-current-dir _directory)
+            'safe))
+         (default-directory "/tmp/normal-project/"))
+     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (functionp mode-id-fn))
+       (should (equal "default" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-safe-policy-ignores-prefix ()
+  "Test safe-directory policy applies regardless of startup prefix mode."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-test--agent-shell-config
+          '((:identifier . claude-code)
+            (:buffer-name . "Claude Code")))
+         (meta-agent-shell-safe-directory-prefixes '("/tmp/secretary"))
+         (default-directory "/tmp/secretary/project/"))
+     (meta-agent-shell-default-start-function '(4) "Worker")
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (functionp mode-id-fn))
+       (should (equal "default" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-codex-aggressive-mode ()
+  "Test Codex uses the mapped aggressive mode id by default."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-test--agent-shell-config
+          '((:identifier . codex)
+            (:buffer-name . "Codex")))
+         (default-directory "/tmp/normal-project/"))
+     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (functionp mode-id-fn))
+       (should (equal "full-access" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-codex-safe-mode ()
+  "Test Codex uses the mapped safe mode id in safe directories."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-test--agent-shell-config
+          '((:identifier . codex)
+            (:buffer-name . "Codex")))
+         (meta-agent-shell-safe-directory-prefixes '("/tmp/secretary"))
+         (default-directory "/tmp/secretary/project/"))
+     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (functionp mode-id-fn))
+       (should (equal "auto" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-default-start-function-mode-map-uses-config-identifier ()
+  "Test provider mapping keys off config `:identifier' when config is an alist."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-test--agent-shell-config
+          '((:identifier . codex)
+            (:buffer-name . "Codex")
+            (:mode-line-name . "Codex")))
+         (default-directory "/tmp/normal-project/"))
+     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
+     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
+            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
+       (should (equal "full-access" (funcall mode-id-fn)))))))
+
+(ert-deftest meta-agent-shell-test-start-named-agent-uses-actual-buffer-name ()
+  "Test named-agent bookkeeping uses the actual created buffer name."
+  (meta-agent-shell-test--with-clean-state
+   (let ((project-dir (meta-agent-shell-test--create-temp-dir))
+         (meta-agent-shell-start-function #'meta-agent-shell-default-start-function))
+     (let ((buffer-name (meta-agent-shell-start-named-agent project-dir "Worker" "Do thing" t)))
+       (should (stringp buffer-name))
+       (should (equal "Worker Agent @ test-project" buffer-name))
+       (should (member buffer-name meta-agent-shell--allowed-targets))
+       (should (equal "Do thing"
+                      (gethash buffer-name meta-agent-shell--initial-tasks)))))))
+
+(ert-deftest meta-agent-shell-test-custom-start-function-override-still-works ()
+  "Test users can still override `meta-agent-shell-start-function'."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-agent-shell-start-function
+          (lambda (&optional _arg _buffer-name)
+            (switch-to-buffer (get-buffer-create "Custom Agent @ test-project")))))
+     (should (equal "Custom Agent @ test-project"
+                    (meta-agent-shell-start-agent (meta-agent-shell-test--create-temp-dir)))))))
+
+(ert-deftest meta-agent-shell-test-start-dispatcher-with-default-wrapper ()
+  "Test dispatcher startup works with the package-owned default wrapper."
+  (meta-agent-shell-test--with-clean-state
+   (let ((project-dir (meta-agent-shell-test--create-temp-dir))
+         (meta-agent-shell-start-function #'meta-agent-shell-default-start-function))
+     (let ((buffer-name (meta-agent-shell-start-dispatcher project-dir)))
+       (should (equal "Dispatcher Agent @ test-project" buffer-name))
+       (should (= 1 (length meta-agent-shell-test--agent-shell-start-calls)))
+       (should (= 1 (length meta-agent-shell--dispatchers)))))))
+
+(ert-deftest meta-agent-shell-test-start-meta-with-default-wrapper ()
+  "Test meta-agent startup works with the package-owned default wrapper."
+  (meta-agent-shell-test--with-clean-state
+   (let ((meta-dir (meta-agent-shell-test--create-temp-dir))
+         (meta-agent-shell-start-function #'meta-agent-shell-default-start-function))
+     (let ((meta-agent-shell-directory meta-dir))
+       (meta-agent-shell-start)
+       (should (buffer-live-p meta-agent-shell--buffer))
+       (should (= 1 (length meta-agent-shell-test--agent-shell-start-calls)))))))
+
 (ert-deftest meta-agent-shell-test-list-dispatchers-empty ()
   "Test listing dispatchers when none exist."
   (meta-agent-shell-test--with-clean-state
@@ -599,9 +917,10 @@ Optional PROJECT-PATH sets the default-directory."
               #'meta-agent-shell-test--mock-shell-maker-submit)
              ((symbol-function 'shell-maker-busy)
               #'meta-agent-shell-test--mock-shell-maker-busy))
-     (let* ((temp-dir (make-temp-file "meta-agent-shell-log-" t))
-            (meta-agent-shell-log-directory temp-dir))
-       (push temp-dir meta-agent-shell-test--temp-files)
+     (let* ((temp-dir (meta-agent-shell-test--create-temp-dir))
+            (killed-dir (meta-agent-shell-test--create-temp-dir))
+            (meta-agent-shell-log-directory temp-dir)
+            (meta-agent-shell-killed-agents-directory killed-dir))
        ;; Create a mock agent (simulating spawn)
        (let ((agent (meta-agent-shell-test--make-mock-buffer
                      "Worker @ testproj" "/home/user/testproj/")))
@@ -618,8 +937,7 @@ Optional PROJECT-PATH sets the default-directory."
          ;; Close the agent
          (should (eq t (meta-agent-shell-close-session "Worker @ testproj")))
          ;; List should be empty
-         (should (= 0 (length (meta-agent-shell-list-sessions)))))
-       (delete-directory temp-dir t)))))
+         (should (= 0 (length (meta-agent-shell-list-sessions)))))))))
 
 
 (provide 'meta-agent-shell-test)

--- a/meta-agent-shell-test.el
+++ b/meta-agent-shell-test.el
@@ -642,15 +642,6 @@ Optional PROJECT-PATH sets the default-directory."
        (insert-file-contents (expand-file-name meta-agent-shell-config-file))
        (should (equal config-content (buffer-string)))))))
 
-(ert-deftest meta-agent-shell-test-package-directory-ignores-current-buffer-file ()
-  "Test package directory detection does not depend on the current buffer file."
-  (meta-agent-shell-test--with-clean-state
-   (with-temp-buffer
-     (setq-local buffer-file-name "/tmp/not-the-package-dir/init.el")
-     (let ((package-dir (meta-agent-shell--package-directory)))
-       (should (file-exists-p (expand-file-name "agent-overview.md" package-dir)))
-       (should (file-exists-p (expand-file-name "bin/agent-shell-list" package-dir)))))))
-
 (ert-deftest meta-agent-shell-test-default-start-function-uses-agent-shell-start ()
   "Test the default start function uses `agent-shell-start'."
   (meta-agent-shell-test--with-clean-state
@@ -687,33 +678,6 @@ Optional PROJECT-PATH sets the default-directory."
        (should-not (plist-get call :command-prefix))
        (should-not (plist-get call :path-resolver-function))))))
 
-(ert-deftest meta-agent-shell-test-default-start-function-safe-directory-policy ()
-  "Test safe directory prefixes force safe policy for Claude Code."
-  (meta-agent-shell-test--with-clean-state
-   (let ((meta-agent-shell-test--agent-shell-config
-          '((:identifier . claude-code)
-            (:buffer-name . "Claude Code")))
-         (meta-agent-shell-safe-directory-prefixes '("/tmp/secretary")))
-     (let ((default-directory "/tmp/secretary/project/"))
-       (meta-agent-shell-default-start-function 'use-current-dir "Worker"))
-     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
-            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
-       (should (functionp mode-id-fn))
-       (should (equal "default" (funcall mode-id-fn)))))))
-
-(ert-deftest meta-agent-shell-test-default-start-function-aggressive-policy-by-default ()
-  "Test Claude Code defaults to aggressive policy outside safe directories."
-  (meta-agent-shell-test--with-clean-state
-   (let ((meta-agent-shell-test--agent-shell-config
-          '((:identifier . claude-code)
-            (:buffer-name . "Claude Code")))
-         (default-directory "/tmp/normal-project/"))
-     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
-     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
-            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
-       (should (functionp mode-id-fn))
-       (should (equal "bypassPermissions" (funcall mode-id-fn)))))))
-
 (ert-deftest meta-agent-shell-test-default-start-function-session-policy-override ()
   "Test session policy override can force safe mode without replacing the wrapper."
   (meta-agent-shell-test--with-clean-state
@@ -730,20 +694,6 @@ Optional PROJECT-PATH sets the default-directory."
        (should (functionp mode-id-fn))
        (should (equal "default" (funcall mode-id-fn)))))))
 
-(ert-deftest meta-agent-shell-test-default-start-function-safe-policy-ignores-prefix ()
-  "Test safe-directory policy applies regardless of startup prefix mode."
-  (meta-agent-shell-test--with-clean-state
-   (let ((meta-agent-shell-test--agent-shell-config
-          '((:identifier . claude-code)
-            (:buffer-name . "Claude Code")))
-         (meta-agent-shell-safe-directory-prefixes '("/tmp/secretary"))
-         (default-directory "/tmp/secretary/project/"))
-     (meta-agent-shell-default-start-function '(4) "Worker")
-     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
-            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
-       (should (functionp mode-id-fn))
-       (should (equal "default" (funcall mode-id-fn)))))))
-
 (ert-deftest meta-agent-shell-test-default-start-function-codex-aggressive-mode ()
   "Test Codex uses the mapped aggressive mode id by default."
   (meta-agent-shell-test--with-clean-state
@@ -755,33 +705,6 @@ Optional PROJECT-PATH sets the default-directory."
      (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
             (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
        (should (functionp mode-id-fn))
-       (should (equal "full-access" (funcall mode-id-fn)))))))
-
-(ert-deftest meta-agent-shell-test-default-start-function-codex-safe-mode ()
-  "Test Codex uses the mapped safe mode id in safe directories."
-  (meta-agent-shell-test--with-clean-state
-   (let ((meta-agent-shell-test--agent-shell-config
-          '((:identifier . codex)
-            (:buffer-name . "Codex")))
-         (meta-agent-shell-safe-directory-prefixes '("/tmp/secretary"))
-         (default-directory "/tmp/secretary/project/"))
-     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
-     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
-            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
-       (should (functionp mode-id-fn))
-       (should (equal "auto" (funcall mode-id-fn)))))))
-
-(ert-deftest meta-agent-shell-test-default-start-function-mode-map-uses-config-identifier ()
-  "Test provider mapping keys off config `:identifier' when config is an alist."
-  (meta-agent-shell-test--with-clean-state
-   (let ((meta-agent-shell-test--agent-shell-config
-          '((:identifier . codex)
-            (:buffer-name . "Codex")
-            (:mode-line-name . "Codex")))
-         (default-directory "/tmp/normal-project/"))
-     (meta-agent-shell-default-start-function 'use-current-dir "Worker")
-     (let* ((call (car meta-agent-shell-test--agent-shell-start-calls))
-            (mode-id-fn (map-elt (plist-get call :config) :default-session-mode-id)))
        (should (equal "full-access" (funcall mode-id-fn)))))))
 
 (ert-deftest meta-agent-shell-test-start-named-agent-uses-actual-buffer-name ()
@@ -814,16 +737,6 @@ Optional PROJECT-PATH sets the default-directory."
        (should (equal "Dispatcher Agent @ test-project" buffer-name))
        (should (= 1 (length meta-agent-shell-test--agent-shell-start-calls)))
        (should (= 1 (length meta-agent-shell--dispatchers)))))))
-
-(ert-deftest meta-agent-shell-test-start-meta-with-default-wrapper ()
-  "Test meta-agent startup works with the package-owned default wrapper."
-  (meta-agent-shell-test--with-clean-state
-   (let ((meta-dir (meta-agent-shell-test--create-temp-dir))
-         (meta-agent-shell-start-function #'meta-agent-shell-default-start-function))
-     (let ((meta-agent-shell-directory meta-dir))
-       (meta-agent-shell-start)
-       (should (buffer-live-p meta-agent-shell--buffer))
-       (should (= 1 (length meta-agent-shell-test--agent-shell-start-calls)))))))
 
 (ert-deftest meta-agent-shell-test-list-dispatchers-empty ()
   "Test listing dispatchers when none exist."

--- a/meta-agent-shell.el
+++ b/meta-agent-shell.el
@@ -83,54 +83,38 @@ These are passed as the first argument (e.g., prefix arg)."
   :type 'list
   :group 'meta-agent-shell)
 
-(defcustom meta-agent-shell-container-mode-settings nil
-  "Container-mode settings used by `meta-agent-shell-default-start-function'.
+(defcustom meta-agent-shell-before-start-hook nil
+  "Hook run before `meta-agent-shell-default-start-function' starts a session.
 
-When non-nil, should be a plist supporting the following keys:
-
-- `:command-prefix'           Prefix command list/function for container mode.
-- `:path-resolver-function'   Path resolver function for container mode.
-
-When nil, container-mode branches preserve their mode structure but do not
-apply any container-specific overrides."
-  :type '(choice (const :tag "Disabled" nil)
-                 (plist :key-type symbol :value-type sexp))
+Hooks can inspect or update the dynamic variables
+`meta-agent-shell-start-context', `meta-agent-shell-start-directory',
+`meta-agent-shell-start-buffer-name', `meta-agent-shell-start-session-policy',
+`meta-agent-shell-start-command-prefix',
+`meta-agent-shell-start-path-resolver-function', and
+`meta-agent-shell-start-config'."
+  :type 'hook
   :group 'meta-agent-shell)
 
-(defcustom meta-agent-shell-safe-directory-prefixes nil
-  "Directory prefixes that force `safe' startup policy.
+(defcustom meta-agent-shell-after-start-hook nil
+  "Hook run after `meta-agent-shell-default-start-function' starts a session.
 
-If the startup directory is under any listed prefix, the package treats the
-session as `safe' regardless of prefix arg.  This is intended for portable
-project-specific safety overrides such as the maintainer's secretary setup."
-  :type '(repeat directory)
-  :group 'meta-agent-shell)
-
-(defcustom meta-agent-shell-session-policy-function nil
-  "Optional function returning startup policy for a new session.
-
-Called with (CONFIG USE-CONTAINER USE-CURRENT-DIR DIRECTORY) and should
-return one of the symbols `safe', `aggressive', or nil.  A nil return falls
-back to `meta-agent-shell''s default policy logic.
-
-This is an advanced override.  Prefer `meta-agent-shell-safe-directory-prefixes'
-for common path-based safety rules."
-  :type '(choice (const :tag "Default policy" nil)
-                 function)
+Runs with the started session buffer current. The same dynamic start variables
+remain available for post-start setup."
+  :type 'hook
   :group 'meta-agent-shell)
 
 (defcustom meta-agent-shell-session-mode-map
   '((claude-code :safe "default" :aggressive "bypassPermissions")
     (codex :safe "auto" :aggressive "full-access"))
-  "Mapping from provider identifier and package policy to session mode id.
+  "Mapping from provider identifier and abstract policy to session mode id.
 
 Each entry is of the form:
 
   (IDENTIFIER :safe SAFE-MODE-ID :aggressive AGGRESSIVE-MODE-ID)
 
-Policies are computed by `meta-agent-shell' and then translated into
-provider-specific session mode ids using this map.  IDENTIFIER comes from
-the resolved agent config's `:identifier' entry."
+When a start spec supplies `:session-policy', `meta-agent-shell' translates
+that abstract value into the provider-specific mode id using this map.
+IDENTIFIER comes from the resolved agent config's `:identifier' entry."
   :type '(repeat (list symbol
                        (const :safe)
                        (choice (const nil) string)
@@ -159,7 +143,7 @@ Agent state is stored as JSON files under <dir>/<project>/<agent-name>.json."
 (defcustom meta-agent-shell-before-spawn-hook nil
   "Hook run before spawning a new named agent.
 Called before the agent is created, useful for setting up window layout.
-The current buffer and default-directory are already set to the project."
+The current buffer and `default-directory' are already set to the project."
   :type 'hook
   :group 'meta-agent-shell)
 
@@ -171,7 +155,7 @@ Useful for post-spawn setup that needs the agent buffer."
   :group 'meta-agent-shell)
 
 (defcustom meta-agent-shell-restrict-targets nil
-  "When non-nil, only allow messaging buffers in `meta-agent-shell-allowed-targets'.
+  "When t, only allow messaging buffers in `meta-agent-shell-allowed-targets'.
 Set to t for sandboxed workflows where dispatcher has limited permissions."
   :type 'boolean
   :group 'meta-agent-shell)
@@ -202,10 +186,47 @@ Use `meta-agent-shell-allow-target' to add buffers.")
 Used by `meta-agent-shell-start' and `meta-agent-shell-start-dispatcher'
 to pass the outgoing-request-decorator through custom start functions.")
 
+(defvar meta-agent-shell-start-context nil
+  "Dynamically bound context for the current package-managed session start.
+
+Intended values include nil, `meta', `dispatcher', and `named-agent'. User
+customization code can inspect this from
+`meta-agent-shell-before-start-hook' and `meta-agent-shell-after-start-hook'.")
+
+(defvar meta-agent-shell-start-directory nil
+  "Dynamically bound startup directory for the current session start.
+
+`meta-agent-shell-before-start-hook' may set this to redirect the start
+directory while preserving the package-owned start flow.")
+
+(defvar meta-agent-shell-start-buffer-name nil
+  "Dynamically bound buffer name override for the current session start.
+
+When non-nil, `meta-agent-shell-default-start-function' inserts this into the
+resolved `agent-shell' config before calling `agent-shell-start'.")
+
+(defvar meta-agent-shell-start-session-policy nil
+  "Dynamically bound abstract session policy for the current session start.
+
+Supported values are `safe', `aggressive', or nil. When non-nil, the default
+wrapper translates it to a provider-specific session mode id using
+`meta-agent-shell-session-mode-map'.")
+
+(defvar meta-agent-shell-start-command-prefix nil
+  "Dynamically bound command prefix override for the current session start.")
+
+(defvar meta-agent-shell-start-path-resolver-function nil
+  "Dynamically bound path resolver override for the current session start.")
+
+(defvar meta-agent-shell-start-config nil
+  "Dynamically bound base `agent-shell' config for the current session start.
+
+`meta-agent-shell-before-start-hook' may replace or adjust this config before
+the default wrapper applies buffer-name or session-policy overrides.")
+
 (defun meta-agent-shell--inject-decorator (orig-fn &rest args)
-  "Advice for `agent-shell-start' to inject a pending decorator.
-When `meta-agent-shell--pending-decorator' is non-nil, passes it as
-the :outgoing-request-decorator keyword argument."
+  "Call ORIG-FN with ARGS.
+Injects `:outgoing-request-decorator' when `meta-agent-shell--pending-decorator' is non-nil."
   (if meta-agent-shell--pending-decorator
       (apply orig-fn :outgoing-request-decorator meta-agent-shell--pending-decorator args)
     (apply orig-fn args)))
@@ -301,7 +322,7 @@ Returns buffer name or nil if not found."
 
 ;;;###autoload
 (defun meta-agent-shell-project-path (pid)
-  "Return the default-directory of the agent-shell session that owns process PID.
+  "Return the `default-directory' of the agent-shell session that owns process PID.
 PID should be the shell's $$ or a descendant process.
 Returns directory path or nil if not found."
   (when-let ((buf-name (meta-agent-shell--find-buffer-by-client-pid pid)))
@@ -490,29 +511,13 @@ Expands @file references relative to the package directory."
            (agent-shell-select-config :prompt "Start agent: "))
       (user-error "No agent-shell config available; configure `agent-shell-preferred-agent-config' or start from an existing agent-shell buffer")))
 
-(defun meta-agent-shell-default-session-mode-function (config use-container use-current-dir directory)
-  "Return a session mode id for CONFIG, or nil.
-Preserves provider-configured defaults unless meta-agent-shell has an
-explicit override from `meta-agent-shell-session-policy-function' or a
-matching `meta-agent-shell-safe-directory-prefixes' entry."
-  (pcase-let* ((`(,policy . ,source)
-                (meta-agent-shell--session-policy-with-source
-                 config use-container use-current-dir directory))
-               (mapped-mode-id
-                (meta-agent-shell--session-mode-id-for-policy
-                 (map-elt config :identifier)
-                 policy))
-               (configured-mode-id
-                (meta-agent-shell--configured-session-mode-id config)))
-    (cond
-     ((and (memq source '(:session-policy-function :safe-directory))
-           mapped-mode-id)
-      mapped-mode-id)
-     (configured-mode-id
-      configured-mode-id)
-     (mapped-mode-id
-      mapped-mode-id)
-     (t nil))))
+(defun meta-agent-shell-default-session-mode-function (config session-policy)
+  "Return a session mode id for CONFIG and SESSION-POLICY, or nil.
+When SESSION-POLICY is nil, preserve the provider's configured default mode."
+  (and session-policy
+       (meta-agent-shell--session-mode-id-for-policy
+        (map-elt config :identifier)
+        session-policy)))
 
 (defun meta-agent-shell--session-mode-id-for-policy (identifier policy)
   "Return session mode id for IDENTIFIER and POLICY, or nil."
@@ -522,56 +527,6 @@ matching `meta-agent-shell-safe-directory-prefixes' entry."
                  ('safe :safe)
                  ('aggressive :aggressive)
                  (_ nil)))))
-
-(defun meta-agent-shell--directory-safe-p (directory)
-  "Return non-nil when DIRECTORY is under a safe directory prefix."
-  (let ((expanded-directory (file-name-as-directory (expand-file-name directory))))
-    (cl-some (lambda (prefix)
-               (string-prefix-p
-                (file-name-as-directory (expand-file-name prefix))
-                expanded-directory))
-             meta-agent-shell-safe-directory-prefixes)))
-
-(defun meta-agent-shell--default-session-policy (_config _use-container _use-current-dir directory)
-  "Return the default package-level startup policy for DIRECTORY.
-Directories under `meta-agent-shell-safe-directory-prefixes' use `safe'; all
-others use `aggressive'."
-  (if (meta-agent-shell--directory-safe-p directory)
-      'safe
-    'aggressive))
-
-(defun meta-agent-shell--session-policy-with-source (config use-container use-current-dir directory)
-  "Return the effective startup policy for CONFIG in DIRECTORY and its source.
-Returns a cons cell of the form (POLICY . SOURCE), where SOURCE is one of
-`:session-policy-function', `:safe-directory', or `:default'."
-  (let ((override (and meta-agent-shell-session-policy-function
-                       (funcall meta-agent-shell-session-policy-function
-                                config use-container use-current-dir directory))))
-    (cond
-     (override
-      (cons override :session-policy-function))
-     ((meta-agent-shell--directory-safe-p directory)
-      (cons 'safe :safe-directory))
-     (t
-      (cons 'aggressive :default)))))
-
-(defun meta-agent-shell--session-policy (config use-container use-current-dir directory)
-  "Return the effective startup policy for CONFIG in DIRECTORY.
-Uses `meta-agent-shell-session-policy-function' when it returns non-nil,
-otherwise falls back to `meta-agent-shell--default-session-policy'."
-  (car (meta-agent-shell--session-policy-with-source
-        config use-container use-current-dir directory)))
-
-(defun meta-agent-shell--configured-session-mode-id (config)
-  "Return CONFIG's current provider-defined session mode id, or nil."
-  (when-let ((mode-id-fn (map-elt config :default-session-mode-id)))
-    (when (functionp mode-id-fn)
-      (funcall mode-id-fn))))
-
-(defun meta-agent-shell--container-setting (key)
-  "Return KEY from `meta-agent-shell-container-mode-settings'."
-  (when meta-agent-shell-container-mode-settings
-    (plist-get meta-agent-shell-container-mode-settings key)))
 
 (defun meta-agent-shell--call-start-function (&rest args)
   "Call `meta-agent-shell-start-function' with ARGS and return a buffer.
@@ -587,43 +542,51 @@ current buffer after the call."
   "Default start function used by `meta-agent-shell'.
 
 ARG supports these call patterns:
-- nil: normal mode, git root directory
-- \='(4): container mode, git root directory
-- \='(16): container mode, current directory
-- \='use-current-dir: normal mode, current directory (programmatic use)
+- nil: use the current `default-directory'
+- \='use-current-dir: package-internal marker for named-agent starts
 
 Optional BUFFER-NAME overrides the config buffer name."
   (interactive "P")
-  (let* ((use-container (and (consp arg) (not (eq arg 'use-current-dir))))
-         (use-current-dir (or (equal arg '(16)) (eq arg 'use-current-dir)))
-         (directory default-directory)
-         (command-prefix (and use-container
-                              (meta-agent-shell--container-setting :command-prefix)))
-         (path-resolver (and use-container
-                             (meta-agent-shell--container-setting :path-resolver-function)))
-         (config (copy-tree (meta-agent-shell--resolve-start-config)))
-         (session-mode-id (meta-agent-shell-default-session-mode-function
-                           config use-container use-current-dir directory))
-         (agent-shell-cwd-function (when use-current-dir
-                                     (lambda () directory)))
-         (agent-shell-command-prefix (or command-prefix agent-shell-command-prefix))
-         (agent-shell-path-resolver-function (or path-resolver agent-shell-path-resolver-function)))
-    (when buffer-name
-      (setq config (map-insert config :buffer-name buffer-name)))
-    (when session-mode-id
-      (setq config (map-insert config :default-session-mode-id
-                               (lambda () session-mode-id))))
-    (let ((buf (agent-shell-start :config config)))
-      (when (buffer-live-p buf)
-        (with-current-buffer buf
-          (when use-current-dir
-            (setq-local agent-shell-cwd-function (lambda () directory)))
-          (when use-container
+  (let* ((use-current-dir (eq arg 'use-current-dir))
+         (meta-agent-shell-start-directory default-directory)
+         (meta-agent-shell-start-buffer-name buffer-name)
+         (meta-agent-shell-start-session-policy nil)
+         (meta-agent-shell-start-command-prefix nil)
+         (meta-agent-shell-start-path-resolver-function nil)
+         (meta-agent-shell-start-config
+          (copy-tree (meta-agent-shell--resolve-start-config))))
+    (run-hooks 'meta-agent-shell-before-start-hook)
+    (let* ((directory meta-agent-shell-start-directory)
+           (command-prefix meta-agent-shell-start-command-prefix)
+           (path-resolver meta-agent-shell-start-path-resolver-function)
+           (config (copy-tree meta-agent-shell-start-config))
+           (session-mode-id (meta-agent-shell-default-session-mode-function
+                             config meta-agent-shell-start-session-policy))
+           (agent-shell-cwd-function (when use-current-dir
+                                       (lambda () directory)))
+           (agent-shell-command-prefix
+            (or command-prefix agent-shell-command-prefix))
+           (agent-shell-path-resolver-function
+            (or path-resolver agent-shell-path-resolver-function)))
+      (when meta-agent-shell-start-buffer-name
+        (setq config (map-insert config :buffer-name
+                                 meta-agent-shell-start-buffer-name)))
+      (when session-mode-id
+        (setq config (map-insert config :default-session-mode-id
+                                 (lambda () session-mode-id))))
+      (let* ((default-directory directory)
+             (buf (agent-shell-start :config config)))
+        (when (buffer-live-p buf)
+          (with-current-buffer buf
+            (when use-current-dir
+              (setq-local agent-shell-cwd-function (lambda () directory)))
             (when command-prefix
               (setq-local agent-shell-command-prefix command-prefix))
             (when path-resolver
-              (setq-local agent-shell-path-resolver-function path-resolver)))))
-      buf)))
+              (setq-local agent-shell-path-resolver-function path-resolver))
+            (let ((meta-agent-shell-start-config config))
+              (run-hooks 'meta-agent-shell-after-start-hook))))
+        buf))))
 
 (defun meta-agent-shell--format-heartbeat ()
   "Format heartbeat message with session status and user's heartbeat.org.
@@ -732,6 +695,23 @@ Only sends if session is alive and cooldown has elapsed."
   (directory-file-name
    (file-name-directory (expand-file-name meta-agent-shell-config-file))))
 
+(defun meta-agent-shell--ensure-support-bin-on-path ()
+  "Ensure the setup-managed support bin dir is present in PATH and `exec-path`."
+  (when-let* ((bin-dir (expand-file-name "bin" (meta-agent-shell--setup-support-directory)))
+              ((file-directory-p bin-dir)))
+    (let* ((current-path (parse-colon-path (or (getenv "PATH") "")))
+           (path-parts (if (member bin-dir current-path)
+                           current-path
+                         (cons bin-dir current-path)))
+           (clean-exec-path (delete-dups (append exec-path nil))))
+      (setenv "PATH" (mapconcat #'identity path-parts path-separator))
+      (unless (member bin-dir clean-exec-path)
+        (setq exec-path (cons bin-dir clean-exec-path)))
+      (setq-default eshell-path-env (getenv "PATH")))))
+
+;; Ensure the support bin dir is present in PATH when the package loads.
+(meta-agent-shell--ensure-support-bin-on-path)
+
 (defun meta-agent-shell--copy-setup-file (source target created updated)
   "Copy SOURCE to TARGET, updating CREATED and UPDATED lists.
 Returns a list of the form (CREATED UPDATED)."
@@ -815,13 +795,12 @@ Returns a list of the form (CREATED UPDATED)."
           (dolist (path removed)
             (insert (format "- %s\n" path)))
         (insert "- No legacy items removed\n"))
+      (insert (format "\nmeta-agent-shell will add its support script directory %s/bin to Emacs PATH and exec-path automatically.\n" support-dir))
       (insert "\nManual next steps:\n")
-      (insert (format "1. Add to your shell config (.bashrc/.zshrc):\n   export PATH=\"%s/bin:$PATH\"\n\n"
-                      support-dir))
-      (insert "2. Add the following line to your agent instructions file:\n")
+      (insert "1. Add the following line to your agent instructions file:\n")
       (insert "   (for example, ~/.codex/AGENTS.md or ~/.claude/CLAUDE.md)\n")
       (insert (format "   @%s\n\n" agent-overview))
-      (insert (format "3. Edit %s to add @file references for persistent meta-agent context.\n"
+      (insert (format "2. Edit %s to add @file references for persistent meta-agent context.\n"
                       (expand-file-name meta-agent-shell-config-file)))
       (buffer-string))))
 
@@ -876,6 +855,7 @@ This replaces the filesystem work previously done by `./setup.sh'."
       (push legacy-claude removed))
      ((file-exists-p legacy-claude)
       (push legacy-claude existing)))
+    (meta-agent-shell--ensure-support-bin-on-path)
     (meta-agent-shell--display-setup-summary
      (meta-agent-shell--format-setup-summary
       (nreverse created)
@@ -902,9 +882,10 @@ Config from `meta-agent-shell-config-file' is included."
            (buf nil))
       ;; Ensure directory exists
       (make-directory default-directory t)
-      (setq buf
-            (apply #'meta-agent-shell--call-start-function
-                   meta-agent-shell-start-function-args))
+      (let ((meta-agent-shell-start-context 'meta))
+        (setq buf
+              (apply #'meta-agent-shell--call-start-function
+                     meta-agent-shell-start-function-args)))
       ;; Track this as the meta buffer
       (setq meta-agent-shell--buffer buf)
       (message "Meta-agent session started in %s" default-directory))))
@@ -1193,8 +1174,7 @@ Returns the buffer name of the new session, or nil if folder doesn't exist.
 
 Note: `meta-agent-shell-start-function' must:
 - Accept (ARG &optional BUFFER-NAME), or tolerate an omitted ARG
-- Recognize \\='use-current-dir as ARG to use `default-directory' without
-  treating it as container mode (unlike \\='(16), which may do so)
+- Recognize \\='use-current-dir as ARG to use `default-directory'
 - Accept BUFFER-NAME as the second argument for naming the buffer"
   (let ((dir (expand-file-name folder)))
     (if (file-directory-p dir)
@@ -1237,17 +1217,19 @@ Note: `meta-agent-shell-start-function' must:
             ;; Workaround: agent-shell may fail if a buffer with this name was
             ;; recently killed (async cleanup race). Retry once after brief delay.
             (condition-case err
-                (setq buf
-                      (meta-agent-shell--call-start-function
-                       start-arg
-                       buffer-name))
+                (let ((meta-agent-shell-start-context 'named-agent))
+                  (setq buf
+                        (meta-agent-shell--call-start-function
+                         start-arg
+                         buffer-name)))
               (error
                (message "Agent start failed (%s), retrying after cleanup delay..." err)
                (sit-for 0.5)  ; allow pending events to process
-               (setq buf
-                     (meta-agent-shell--call-start-function
-                      start-arg
-                      buffer-name))))
+               (let ((meta-agent-shell-start-context 'named-agent))
+                 (setq buf
+                       (meta-agent-shell--call-start-function
+                        start-arg
+                        buffer-name)))))
             (setq actual-buffer-name (buffer-name buf))
             ;; Auto-register if restrictions are enabled or explicitly requested
             (when (or auto-allow meta-agent-shell-restrict-targets)
@@ -1318,82 +1300,21 @@ Returns the number of sessions interrupted."
 ;;; Dispatcher functions - project-level message routing
 
 ;;;###autoload
-(defconst meta-agent-shell--dispatcher-instructions
-  "You are a **project dispatcher**. Your job is to route work to agents and coordinate them.
+(defun meta-agent-shell--read-packaged-markdown (filename)
+  "Return the contents of packaged markdown FILENAME.
+Expand `@file' references relative to the package directory."
+  (let* ((pkg-dir (meta-agent-shell--package-directory))
+         (path (expand-file-name filename pkg-dir)))
+    (unless (file-exists-p path)
+      (error "Missing meta-agent-shell resource: %s" path))
+    (let ((raw (with-temp-buffer
+                 (insert-file-contents path)
+                 (buffer-string))))
+      (meta-agent-shell--expand-file-refs raw pkg-dir))))
 
-## Key Principles
-
-1. **Route work, don't do it yourself.** Find the right agent and delegate.
-2. **Use `agent-shell-ask` when you need a response.** The reply arrives automatically.
-3. **Be available for conversation.** The user may want to discuss strategy or priorities.
-
-## Your Tools
-
-These are **shell commands**. Execute them directly in your shell (via the Bash tool). Do NOT send them as messages to yourself or other agents.
-
-### Spawn a new agent
-```bash
-agent-shell-spawn \"AgentName\" \"initial task description\"
-```
-This creates a new agent session and sends it the initial task. The agent name should be short and descriptive (e.g., \"WildGuard\", \"Tests\", \"Refactor\").
-
-### Send a message to an existing agent
-```bash
-agent-shell-send \"BUFFER-NAME\" \"message\"
-```
-
-### Ask an agent a question (they reply back to you automatically)
-```bash
-agent-shell-ask \"BUFFER-NAME\" \"question\"
-```
-
-### List active agents
-```bash
-agent-shell-list
-```
-
-### View recent output from an agent
-```bash
-agent-shell-view \"BUFFER-NAME\" 50
-```
-
-### Interrupt a runaway agent
-```bash
-agent-shell-interrupt \"BUFFER-NAME\"
-```
-
-## Common Mistakes
-
-- **WRONG:** `emacsclient --eval '(some-elisp-function ...)'` — do NOT use emacsclient to spawn or manage agents
-- **WRONG:** `agent-shell-send \"Dispatcher\" \"spawn AgentName ...\"` — this sends a text message, it does NOT spawn anything
-- **RIGHT:** `agent-shell-spawn \"AgentName\" \"task description\"` — this actually creates a new agent
-
-All agent management is done through `agent-shell-*` CLI commands, never through emacsclient.
-
-**Buffer names** follow the format `AgentName Agent @ projectname` (e.g., `Worker Agent @ myproject`).
-Use `agent-shell-list` to get exact buffer names before sending messages.
-
-## Workflow
-
-1. Check which agents exist with `agent-shell-list`
-2. Route to existing agent, or spawn a new named agent with `agent-shell-spawn`
-3. For status checks, use `agent-shell-ask` to query agents
-
-## Emergency Stop
-
-```bash
-emacsclient --eval '(meta-agent-shell-big-red-button)'
-```
-
-Interrupts (not kills) all agent sessions, including yourself.
-
-## Agent Guidelines
-
-When spawning agents, they should:
-- Complete their assigned task
-- If appropriate, commit changes with a descriptive message before reporting back
-- Report completion to their spawner"
-  "Instructions sent to dispatchers at startup.")
+(defun meta-agent-shell--dispatcher-instructions ()
+  "Return dispatcher instructions."
+  (meta-agent-shell--read-packaged-markdown "dispatcher-instructions.md"))
 
 (defun meta-agent-shell-start-dispatcher (project-path)
   "Start a dispatcher for PROJECT-PATH.
@@ -1419,24 +1340,26 @@ outgoing-request-decorator, so they persist across context compaction."
       ;; Create dispatcher in the project directory itself
       (let* ((dispatcher-buffer-name "Dispatcher")
              (default-directory project-path)
-             (instructions meta-agent-shell--dispatcher-instructions)
+             (instructions (meta-agent-shell--dispatcher-instructions))
              (session-meta `((systemPrompt . ((append . ,instructions)))))
              (meta-agent-shell--pending-decorator
               (meta-agent-shell--make-session-meta-decorator session-meta))
              (buf nil))
         ;; Use the configured start function to create the buffer
         (condition-case err
-            (setq buf
-                  (meta-agent-shell--call-start-function
-                   (car meta-agent-shell-start-function-args)
-                   dispatcher-buffer-name))
+            (let ((meta-agent-shell-start-context 'dispatcher))
+              (setq buf
+                    (meta-agent-shell--call-start-function
+                     (car meta-agent-shell-start-function-args)
+                     dispatcher-buffer-name)))
           (error
            (message "Dispatcher start failed (%s), retrying after cleanup delay..." err)
            (sit-for 0.5)
-           (setq buf
-                 (meta-agent-shell--call-start-function
-                  (car meta-agent-shell-start-function-args)
-                  dispatcher-buffer-name))))
+           (let ((meta-agent-shell-start-context 'dispatcher))
+             (setq buf
+                   (meta-agent-shell--call-start-function
+                    (car meta-agent-shell-start-function-args)
+                    dispatcher-buffer-name)))))
         ;; Register dispatcher
         (push (cons project-path buf) meta-agent-shell--dispatchers)
         (message "Dispatcher started for %s (instructions in system prompt)" project-name)

--- a/meta-agent-shell.el
+++ b/meta-agent-shell.el
@@ -491,12 +491,28 @@ Expands @file references relative to the package directory."
       (user-error "No agent-shell config available; configure `agent-shell-preferred-agent-config' or start from an existing agent-shell buffer")))
 
 (defun meta-agent-shell-default-session-mode-function (config use-container use-current-dir directory)
-  "Return a default session mode id for CONFIG, or nil.
-Maps package-level startup policy to provider-specific session mode ids."
-  (meta-agent-shell--session-mode-id-for-policy
-   (map-elt config :identifier)
-   (meta-agent-shell--session-policy
-    config use-container use-current-dir directory)))
+  "Return a session mode id for CONFIG, or nil.
+Preserves provider-configured defaults unless meta-agent-shell has an
+explicit override from `meta-agent-shell-session-policy-function' or a
+matching `meta-agent-shell-safe-directory-prefixes' entry."
+  (pcase-let* ((`(,policy . ,source)
+                (meta-agent-shell--session-policy-with-source
+                 config use-container use-current-dir directory))
+               (mapped-mode-id
+                (meta-agent-shell--session-mode-id-for-policy
+                 (map-elt config :identifier)
+                 policy))
+               (configured-mode-id
+                (meta-agent-shell--configured-session-mode-id config)))
+    (cond
+     ((and (memq source '(:session-policy-function :safe-directory))
+           mapped-mode-id)
+      mapped-mode-id)
+     (configured-mode-id
+      configured-mode-id)
+     (mapped-mode-id
+      mapped-mode-id)
+     (t nil))))
 
 (defun meta-agent-shell--session-mode-id-for-policy (identifier policy)
   "Return session mode id for IDENTIFIER and POLICY, or nil."
@@ -524,15 +540,33 @@ others use `aggressive'."
       'safe
     'aggressive))
 
+(defun meta-agent-shell--session-policy-with-source (config use-container use-current-dir directory)
+  "Return the effective startup policy for CONFIG in DIRECTORY and its source.
+Returns a cons cell of the form (POLICY . SOURCE), where SOURCE is one of
+`:session-policy-function', `:safe-directory', or `:default'."
+  (let ((override (and meta-agent-shell-session-policy-function
+                       (funcall meta-agent-shell-session-policy-function
+                                config use-container use-current-dir directory))))
+    (cond
+     (override
+      (cons override :session-policy-function))
+     ((meta-agent-shell--directory-safe-p directory)
+      (cons 'safe :safe-directory))
+     (t
+      (cons 'aggressive :default)))))
+
 (defun meta-agent-shell--session-policy (config use-container use-current-dir directory)
   "Return the effective startup policy for CONFIG in DIRECTORY.
 Uses `meta-agent-shell-session-policy-function' when it returns non-nil,
 otherwise falls back to `meta-agent-shell--default-session-policy'."
-  (or (and meta-agent-shell-session-policy-function
-           (funcall meta-agent-shell-session-policy-function
-                    config use-container use-current-dir directory))
-      (meta-agent-shell--default-session-policy
-       config use-container use-current-dir directory)))
+  (car (meta-agent-shell--session-policy-with-source
+        config use-container use-current-dir directory)))
+
+(defun meta-agent-shell--configured-session-mode-id (config)
+  "Return CONFIG's current provider-defined session mode id, or nil."
+  (when-let ((mode-id-fn (map-elt config :default-session-mode-id)))
+    (when (functionp mode-id-fn)
+      (funcall mode-id-fn))))
 
 (defun meta-agent-shell--container-setting (key)
   "Return KEY from `meta-agent-shell-container-mode-settings'."

--- a/meta-agent-shell.el
+++ b/meta-agent-shell.el
@@ -89,7 +89,7 @@ These are passed as the first argument (e.g., prefix arg)."
 Hooks can inspect or update the dynamic variables
 `meta-agent-shell-start-context', `meta-agent-shell-start-directory',
 `meta-agent-shell-start-buffer-name', `meta-agent-shell-start-session-policy',
-`meta-agent-shell-start-command-prefix',
+`meta-agent-shell-start-session-mode-id', `meta-agent-shell-start-command-prefix',
 `meta-agent-shell-start-path-resolver-function', and
 `meta-agent-shell-start-config'."
   :type 'hook
@@ -104,19 +104,21 @@ remain available for post-start setup."
   :group 'meta-agent-shell)
 
 (defcustom meta-agent-shell-session-mode-map
-  '((claude-code :safe "default" :aggressive "bypassPermissions")
-    (codex :safe "auto" :aggressive "full-access"))
+  '((claude-code :safe "dontAsk" :auto "default" :aggressive "bypassPermissions")
+    (codex :safe "read-only" :auto "auto" :aggressive "full-access"))
   "Mapping from provider identifier and abstract policy to session mode id.
 
 Each entry is of the form:
 
-  (IDENTIFIER :safe SAFE-MODE-ID :aggressive AGGRESSIVE-MODE-ID)
+  (IDENTIFIER :safe SAFE-MODE-ID :auto AUTO-MODE-ID :aggressive AGGRESSIVE-MODE-ID)
 
 When a start spec supplies `:session-policy', `meta-agent-shell' translates
 that abstract value into the provider-specific mode id using this map.
 IDENTIFIER comes from the resolved agent config's `:identifier' entry."
   :type '(repeat (list symbol
                        (const :safe)
+                       (choice (const nil) string)
+                       (const :auto)
                        (choice (const nil) string)
                        (const :aggressive)
                        (choice (const nil) string)))
@@ -208,9 +210,17 @@ resolved `agent-shell' config before calling `agent-shell-start'.")
 (defvar meta-agent-shell-start-session-policy nil
   "Dynamically bound abstract session policy for the current session start.
 
-Supported values are `safe', `aggressive', or nil. When non-nil, the default
-wrapper translates it to a provider-specific session mode id using
+Supported values are `safe', `auto', `aggressive', or nil. The default wrapper
+binds this to `auto' for package-managed starts, and translates any non-nil
+value to a provider-specific session mode id using
 `meta-agent-shell-session-mode-map'.")
+
+(defvar meta-agent-shell-start-session-mode-id nil
+  "Dynamically bound raw session mode override for the current session start.
+
+When non-nil, this takes precedence over
+`meta-agent-shell-start-session-policy'. Hooks may bind or set this to a
+provider-specific mode id such as `plan' or \"plan\".")
 
 (defvar meta-agent-shell-start-command-prefix nil
   "Dynamically bound command prefix override for the current session start.")
@@ -222,7 +232,7 @@ wrapper translates it to a provider-specific session mode id using
   "Dynamically bound base `agent-shell' config for the current session start.
 
 `meta-agent-shell-before-start-hook' may replace or adjust this config before
-the default wrapper applies buffer-name or session-policy overrides.")
+the default wrapper applies buffer-name or session mode overrides.")
 
 (defun meta-agent-shell--inject-decorator (orig-fn &rest args)
   "Call ORIG-FN with ARGS.
@@ -511,13 +521,24 @@ Expands @file references relative to the package directory."
            (agent-shell-select-config :prompt "Start agent: "))
       (user-error "No agent-shell config available; configure `agent-shell-preferred-agent-config' or start from an existing agent-shell buffer")))
 
-(defun meta-agent-shell-default-session-mode-function (config session-policy)
-  "Return a session mode id for CONFIG and SESSION-POLICY, or nil.
-When SESSION-POLICY is nil, preserve the provider's configured default mode."
-  (and session-policy
-       (meta-agent-shell--session-mode-id-for-policy
-        (map-elt config :identifier)
-        session-policy)))
+(defun meta-agent-shell--normalize-session-mode-id (mode-id)
+  "Normalize MODE-ID to a provider mode-id string, or nil."
+  (cond
+   ((null mode-id) nil)
+   ((stringp mode-id) mode-id)
+   ((symbolp mode-id) (symbol-name mode-id))
+   (t nil)))
+
+(defun meta-agent-shell-default-session-mode-function
+    (config session-policy explicit-mode-id)
+  "Return a session mode id for CONFIG, SESSION-POLICY, and EXPLICIT-MODE-ID.
+When EXPLICIT-MODE-ID is non-nil, it takes precedence over SESSION-POLICY.
+When both are nil, preserve the provider's configured default mode."
+  (or (meta-agent-shell--normalize-session-mode-id explicit-mode-id)
+      (and session-policy
+           (meta-agent-shell--session-mode-id-for-policy
+            (map-elt config :identifier)
+            session-policy))))
 
 (defun meta-agent-shell--session-mode-id-for-policy (identifier policy)
   "Return session mode id for IDENTIFIER and POLICY, or nil."
@@ -525,6 +546,7 @@ When SESSION-POLICY is nil, preserve the provider's configured default mode."
     (plist-get (cdr entry)
                (pcase policy
                  ('safe :safe)
+                 ('auto :auto)
                  ('aggressive :aggressive)
                  (_ nil)))))
 
@@ -550,7 +572,8 @@ Optional BUFFER-NAME overrides the config buffer name."
   (let* ((use-current-dir (eq arg 'use-current-dir))
          (meta-agent-shell-start-directory default-directory)
          (meta-agent-shell-start-buffer-name buffer-name)
-         (meta-agent-shell-start-session-policy nil)
+         (meta-agent-shell-start-session-policy 'auto)
+         (meta-agent-shell-start-session-mode-id nil)
          (meta-agent-shell-start-command-prefix nil)
          (meta-agent-shell-start-path-resolver-function nil)
          (meta-agent-shell-start-config
@@ -561,7 +584,9 @@ Optional BUFFER-NAME overrides the config buffer name."
            (path-resolver meta-agent-shell-start-path-resolver-function)
            (config (copy-tree meta-agent-shell-start-config))
            (session-mode-id (meta-agent-shell-default-session-mode-function
-                             config meta-agent-shell-start-session-policy))
+                             config
+                             meta-agent-shell-start-session-policy
+                             meta-agent-shell-start-session-mode-id))
            (agent-shell-cwd-function (when use-current-dir
                                        (lambda () directory)))
            (agent-shell-command-prefix

--- a/meta-agent-shell.el
+++ b/meta-agent-shell.el
@@ -67,9 +67,13 @@ If you've messaged the meta session within this time, heartbeat is delayed."
   :type 'string
   :group 'meta-agent-shell)
 
-(defcustom meta-agent-shell-start-function #'agent-shell
+(defcustom meta-agent-shell-start-function #'meta-agent-shell-default-start-function
   "Function to start a new agent-shell session.
-Should accept optional BUFFER-NAME as second argument for named agents."
+Defaults to `meta-agent-shell-default-start-function', a package-owned
+wrapper around `agent-shell-start' that preserves meta-agent-shell's
+buffer-naming and directory-selection behavior.
+
+Custom overrides should accept (ARG &optional BUFFER-NAME)."
   :type 'function
   :group 'meta-agent-shell)
 
@@ -77,6 +81,61 @@ Should accept optional BUFFER-NAME as second argument for named agents."
   "Arguments to pass to `meta-agent-shell-start-function'.
 These are passed as the first argument (e.g., prefix arg)."
   :type 'list
+  :group 'meta-agent-shell)
+
+(defcustom meta-agent-shell-container-mode-settings nil
+  "Container-mode settings used by `meta-agent-shell-default-start-function'.
+
+When non-nil, should be a plist supporting the following keys:
+
+- `:command-prefix'           Prefix command list/function for container mode.
+- `:path-resolver-function'   Path resolver function for container mode.
+
+When nil, container-mode branches preserve their mode structure but do not
+apply any container-specific overrides."
+  :type '(choice (const :tag "Disabled" nil)
+                 (plist :key-type symbol :value-type sexp))
+  :group 'meta-agent-shell)
+
+(defcustom meta-agent-shell-safe-directory-prefixes nil
+  "Directory prefixes that force `safe' startup policy.
+
+If the startup directory is under any listed prefix, the package treats the
+session as `safe' regardless of prefix arg.  This is intended for portable
+project-specific safety overrides such as the maintainer's secretary setup."
+  :type '(repeat directory)
+  :group 'meta-agent-shell)
+
+(defcustom meta-agent-shell-session-policy-function nil
+  "Optional function returning startup policy for a new session.
+
+Called with (CONFIG USE-CONTAINER USE-CURRENT-DIR DIRECTORY) and should
+return one of the symbols `safe', `aggressive', or nil.  A nil return falls
+back to `meta-agent-shell''s default policy logic.
+
+This is an advanced override.  Prefer `meta-agent-shell-safe-directory-prefixes'
+for common path-based safety rules."
+  :type '(choice (const :tag "Default policy" nil)
+                 function)
+  :group 'meta-agent-shell)
+
+(defcustom meta-agent-shell-session-mode-map
+  '((claude-code :safe "default" :aggressive "bypassPermissions")
+    (codex :safe "auto" :aggressive "full-access"))
+  "Mapping from provider identifier and package policy to session mode id.
+
+Each entry is of the form:
+
+  (IDENTIFIER :safe SAFE-MODE-ID :aggressive AGGRESSIVE-MODE-ID)
+
+Policies are computed by `meta-agent-shell' and then translated into
+provider-specific session mode ids using this map.  IDENTIFIER comes from
+the resolved agent config's `:identifier' entry."
+  :type '(repeat (list symbol
+                       (const :safe)
+                       (choice (const nil) string)
+                       (const :aggressive)
+                       (choice (const nil) string)))
   :group 'meta-agent-shell)
 
 (defcustom meta-agent-shell-config-file "~/.meta-agent-shell/config.org"
@@ -408,6 +467,130 @@ Expands @file references relative to the package directory."
                    (buffer-string))))
         (meta-agent-shell--expand-file-refs raw pkg-dir)))))
 
+(defun meta-agent-shell--package-directory ()
+  "Return the package directory for meta-agent-shell resources."
+  (let ((library-file
+         (or load-file-name
+             (and (fboundp 'symbol-file)
+                  (or (symbol-file 'meta-agent-shell--package-directory 'defun)
+                      (symbol-file 'meta-agent-shell-setup 'defun)))
+             (locate-library "meta-agent-shell.el"))))
+    (unless library-file
+      (error "Could not determine meta-agent-shell package directory"))
+    (file-name-directory (file-truename library-file))))
+
+(defun meta-agent-shell--resolve-start-config ()
+  "Resolve the base `agent-shell' config for starting a new session."
+  (or (and (fboundp 'agent-shell-get-config)
+           (derived-mode-p 'agent-shell-mode)
+           (agent-shell-get-config (current-buffer)))
+      (and (fboundp 'agent-shell--resolve-preferred-config)
+           (agent-shell--resolve-preferred-config))
+      (and (fboundp 'agent-shell-select-config)
+           (agent-shell-select-config :prompt "Start agent: "))
+      (user-error "No agent-shell config available; configure `agent-shell-preferred-agent-config' or start from an existing agent-shell buffer")))
+
+(defun meta-agent-shell-default-session-mode-function (config use-container use-current-dir directory)
+  "Return a default session mode id for CONFIG, or nil.
+Maps package-level startup policy to provider-specific session mode ids."
+  (meta-agent-shell--session-mode-id-for-policy
+   (map-elt config :identifier)
+   (meta-agent-shell--session-policy
+    config use-container use-current-dir directory)))
+
+(defun meta-agent-shell--session-mode-id-for-policy (identifier policy)
+  "Return session mode id for IDENTIFIER and POLICY, or nil."
+  (when-let ((entry (assq identifier meta-agent-shell-session-mode-map)))
+    (plist-get (cdr entry)
+               (pcase policy
+                 ('safe :safe)
+                 ('aggressive :aggressive)
+                 (_ nil)))))
+
+(defun meta-agent-shell--directory-safe-p (directory)
+  "Return non-nil when DIRECTORY is under a safe directory prefix."
+  (let ((expanded-directory (file-name-as-directory (expand-file-name directory))))
+    (cl-some (lambda (prefix)
+               (string-prefix-p
+                (file-name-as-directory (expand-file-name prefix))
+                expanded-directory))
+             meta-agent-shell-safe-directory-prefixes)))
+
+(defun meta-agent-shell--default-session-policy (_config _use-container _use-current-dir directory)
+  "Return the default package-level startup policy for DIRECTORY.
+Directories under `meta-agent-shell-safe-directory-prefixes' use `safe'; all
+others use `aggressive'."
+  (if (meta-agent-shell--directory-safe-p directory)
+      'safe
+    'aggressive))
+
+(defun meta-agent-shell--session-policy (config use-container use-current-dir directory)
+  "Return the effective startup policy for CONFIG in DIRECTORY.
+Uses `meta-agent-shell-session-policy-function' when it returns non-nil,
+otherwise falls back to `meta-agent-shell--default-session-policy'."
+  (or (and meta-agent-shell-session-policy-function
+           (funcall meta-agent-shell-session-policy-function
+                    config use-container use-current-dir directory))
+      (meta-agent-shell--default-session-policy
+       config use-container use-current-dir directory)))
+
+(defun meta-agent-shell--container-setting (key)
+  "Return KEY from `meta-agent-shell-container-mode-settings'."
+  (when meta-agent-shell-container-mode-settings
+    (plist-get meta-agent-shell-container-mode-settings key)))
+
+(defun meta-agent-shell--call-start-function (&rest args)
+  "Call `meta-agent-shell-start-function' with ARGS and return a buffer.
+If the configured function does not return a buffer, fall back to the
+current buffer after the call."
+  (let ((result (apply meta-agent-shell-start-function args)))
+    (cond
+     ((bufferp result) result)
+     ((and (stringp result) (get-buffer result)) (get-buffer result))
+     (t (current-buffer)))))
+
+(defun meta-agent-shell-default-start-function (&optional arg buffer-name)
+  "Default start function used by `meta-agent-shell'.
+
+ARG supports these call patterns:
+- nil: normal mode, git root directory
+- \='(4): container mode, git root directory
+- \='(16): container mode, current directory
+- \='use-current-dir: normal mode, current directory (programmatic use)
+
+Optional BUFFER-NAME overrides the config buffer name."
+  (interactive "P")
+  (let* ((use-container (and (consp arg) (not (eq arg 'use-current-dir))))
+         (use-current-dir (or (equal arg '(16)) (eq arg 'use-current-dir)))
+         (directory default-directory)
+         (command-prefix (and use-container
+                              (meta-agent-shell--container-setting :command-prefix)))
+         (path-resolver (and use-container
+                             (meta-agent-shell--container-setting :path-resolver-function)))
+         (config (copy-tree (meta-agent-shell--resolve-start-config)))
+         (session-mode-id (meta-agent-shell-default-session-mode-function
+                           config use-container use-current-dir directory))
+         (agent-shell-cwd-function (when use-current-dir
+                                     (lambda () directory)))
+         (agent-shell-command-prefix (or command-prefix agent-shell-command-prefix))
+         (agent-shell-path-resolver-function (or path-resolver agent-shell-path-resolver-function)))
+    (when buffer-name
+      (setq config (map-insert config :buffer-name buffer-name)))
+    (when session-mode-id
+      (setq config (map-insert config :default-session-mode-id
+                               (lambda () session-mode-id))))
+    (let ((buf (agent-shell-start :config config)))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          (when use-current-dir
+            (setq-local agent-shell-cwd-function (lambda () directory)))
+          (when use-container
+            (when command-prefix
+              (setq-local agent-shell-command-prefix command-prefix))
+            (when path-resolver
+              (setq-local agent-shell-path-resolver-function path-resolver)))))
+      buf)))
+
 (defun meta-agent-shell--format-heartbeat ()
   "Format heartbeat message with session status and user's heartbeat.org.
 The heartbeat file supports @file references (relative to the file's directory)
@@ -502,6 +685,171 @@ Only sends if session is alive and cooldown has elapsed."
                       (map-elt request :params))))
     request))
 
+(defconst meta-agent-shell--setup-config-template
+  "# Meta-agent config - add @file references to include in the system prompt
+# Example:
+# @/absolute/path/to/priorities.org
+# @relative/path/from/here.org
+"
+  "Template written to `meta-agent-shell-config-file' during setup.")
+
+(defun meta-agent-shell--setup-support-directory ()
+  "Return the stable support directory for setup-managed assets."
+  (directory-file-name
+   (file-name-directory (expand-file-name meta-agent-shell-config-file))))
+
+(defun meta-agent-shell--copy-setup-file (source target created updated)
+  "Copy SOURCE to TARGET, updating CREATED and UPDATED lists.
+Returns a list of the form (CREATED UPDATED)."
+  (let* ((target-dir (file-name-directory target))
+         (source-modes (file-modes source))
+         (target-exists (file-exists-p target))
+         (target-modes (and target-exists (file-modes target)))
+         (target-content (and target-exists
+                              (with-temp-buffer
+                                (insert-file-contents target)
+                                (buffer-string))))
+         (source-content (with-temp-buffer
+                           (insert-file-contents source)
+                           (buffer-string))))
+    (unless (file-directory-p target-dir)
+      (make-directory target-dir t))
+    (cond
+     ((not target-exists)
+      (copy-file source target t)
+      (when source-modes
+        (set-file-modes target source-modes))
+      (setq created (cons target created)))
+     ((or (not (equal source-content target-content))
+          (not (equal source-modes target-modes)))
+      (copy-file source target t)
+      (when source-modes
+        (set-file-modes target source-modes))
+      (setq updated (cons target updated))))
+    (list created updated)))
+
+(defun meta-agent-shell--sync-setup-assets (support-dir created updated)
+  "Sync setup-managed assets into SUPPORT-DIR.
+CREATED and UPDATED track resulting file changes.
+Returns a list of the form (CREATED UPDATED)."
+  (let* ((package-dir (meta-agent-shell--package-directory))
+         (source-bin-dir (expand-file-name "bin" package-dir))
+         (target-bin-dir (expand-file-name "bin" support-dir))
+         (source-overview (expand-file-name "agent-overview.md" package-dir))
+         (target-overview (expand-file-name "agent-overview.md" support-dir)))
+    (unless (file-directory-p target-bin-dir)
+      (make-directory target-bin-dir t))
+    (dolist (source (directory-files source-bin-dir t "^[^.].*"))
+      (when (file-regular-p source)
+        (pcase-let ((`(,new-created ,new-updated)
+                     (meta-agent-shell--copy-setup-file
+                      source
+                      (expand-file-name (file-name-nondirectory source) target-bin-dir)
+                      created updated)))
+          (setq created new-created
+                updated new-updated))))
+    (pcase-let ((`(,new-created ,new-updated)
+                 (meta-agent-shell--copy-setup-file
+                  source-overview target-overview created updated)))
+      (setq created new-created
+            updated new-updated))
+    (list created updated)))
+
+(defun meta-agent-shell--format-setup-summary (created updated existing removed support-dir)
+  "Format a setup summary from CREATED, UPDATED, EXISTING, REMOVED, and SUPPORT-DIR."
+  (let ((agent-overview (expand-file-name "agent-overview.md" support-dir))
+        (bin-dir (expand-file-name "bin" support-dir)))
+    (with-temp-buffer
+      (insert "meta-agent-shell setup complete\n\n")
+      (insert "Created:\n")
+      (if created
+          (dolist (path created)
+            (insert (format "- %s\n" path)))
+        (insert "- Nothing created\n"))
+      (insert "\nUpdated:\n")
+      (if updated
+          (dolist (path updated)
+            (insert (format "- %s\n" path)))
+        (insert "- Nothing updated\n"))
+      (insert "\nLeft untouched:\n")
+      (if existing
+          (dolist (path existing)
+            (insert (format "- %s\n" path)))
+        (insert "- Nothing to report\n"))
+      (insert "\nRemoved legacy items:\n")
+      (if removed
+          (dolist (path removed)
+            (insert (format "- %s\n" path)))
+        (insert "- No legacy items removed\n"))
+      (insert "\nManual next steps:\n")
+      (insert (format "1. Add to your shell config (.bashrc/.zshrc):\n   export PATH=\"%s/bin:$PATH\"\n\n"
+                      support-dir))
+      (insert "2. Add the following line to your agent instructions file:\n")
+      (insert "   (for example, ~/.codex/AGENTS.md or ~/.claude/CLAUDE.md)\n")
+      (insert (format "   @%s\n\n" agent-overview))
+      (insert (format "3. Edit %s to add @file references for persistent meta-agent context.\n"
+                      (expand-file-name meta-agent-shell-config-file)))
+      (buffer-string))))
+
+(defun meta-agent-shell--display-setup-summary (summary)
+  "Display setup SUMMARY in a dedicated results buffer."
+  (let ((buf (get-buffer-create "*meta-agent-shell setup*")))
+    (with-current-buffer buf
+      (setq buffer-read-only nil)
+      (erase-buffer)
+      (insert summary)
+      (goto-char (point-min))
+      (view-mode 1))
+    (pop-to-buffer buf)))
+
+;;;###autoload
+(defun meta-agent-shell-setup ()
+  "Set up meta-agent-shell support files and directories.
+This replaces the filesystem work previously done by `./setup.sh'."
+  (interactive)
+  (let* ((meta-dir (expand-file-name meta-agent-shell-directory))
+         (legacy-claude (expand-file-name "CLAUDE.md" meta-dir))
+         (log-dir (expand-file-name meta-agent-shell-log-directory))
+         (config-file (expand-file-name meta-agent-shell-config-file))
+         (config-dir (file-name-directory config-file))
+         (support-dir (meta-agent-shell--setup-support-directory))
+         (created nil)
+         (updated nil)
+         (existing nil)
+         (removed nil))
+    (if (file-directory-p meta-dir)
+        (push meta-dir existing)
+      (make-directory meta-dir t)
+      (push meta-dir created))
+    (if (file-directory-p log-dir)
+        (push log-dir existing)
+      (make-directory log-dir t)
+      (push log-dir created))
+    (unless (file-directory-p config-dir)
+      (make-directory config-dir t))
+    (if (file-exists-p config-file)
+        (push config-file existing)
+      (with-temp-file config-file
+        (insert meta-agent-shell--setup-config-template))
+      (push config-file created))
+    (pcase-let ((`(,new-created ,new-updated)
+                 (meta-agent-shell--sync-setup-assets support-dir created updated)))
+      (setq created new-created
+            updated new-updated))
+    (cond
+     ((file-symlink-p legacy-claude)
+      (delete-file legacy-claude)
+      (push legacy-claude removed))
+     ((file-exists-p legacy-claude)
+      (push legacy-claude existing)))
+    (meta-agent-shell--display-setup-summary
+     (meta-agent-shell--format-setup-summary
+      (nreverse created)
+      (nreverse updated)
+      (nreverse existing)
+      (nreverse removed)
+      support-dir))))
+
 (defun meta-agent-shell-start ()
   "Start or switch to the meta-agent session.
 Only one meta session can be active at a time.
@@ -516,12 +864,15 @@ Config from `meta-agent-shell-config-file' is included."
            (base-instructions (meta-agent-shell--meta-instructions))
            (session-meta `((systemPrompt . ((append . ,base-instructions)))))
            (meta-agent-shell--pending-decorator
-            (meta-agent-shell--make-session-meta-decorator session-meta)))
+            (meta-agent-shell--make-session-meta-decorator session-meta))
+           (buf nil))
       ;; Ensure directory exists
       (make-directory default-directory t)
-      (apply meta-agent-shell-start-function meta-agent-shell-start-function-args)
+      (setq buf
+            (apply #'meta-agent-shell--call-start-function
+                   meta-agent-shell-start-function-args))
       ;; Track this as the meta buffer
-      (setq meta-agent-shell--buffer (current-buffer))
+      (setq meta-agent-shell--buffer buf)
       (message "Meta-agent session started in %s" default-directory))))
 
 ;;;###autoload
@@ -779,16 +1130,19 @@ If INITIAL-MESSAGE is provided, send it to the agent after starting.
 Returns the buffer name of the new session, or nil if folder doesn't exist."
   (let ((dir (expand-file-name folder)))
     (if (file-directory-p dir)
-        (let ((default-directory dir))
-          (apply meta-agent-shell-start-function meta-agent-shell-start-function-args)
+        (let ((default-directory dir)
+              (buf nil))
+          (setq buf
+                (apply #'meta-agent-shell--call-start-function
+                       meta-agent-shell-start-function-args))
           (when initial-message
             (run-at-time 0.5 nil
                          (lambda (buf msg)
                            (when (buffer-live-p buf)
                              (with-current-buffer buf
                                (shell-maker-submit :input msg))))
-                         (current-buffer) initial-message))
-          (buffer-name (current-buffer)))
+                         buf initial-message))
+          (buffer-name buf))
       (message "Directory does not exist: %s" dir)
       nil)))
 
@@ -804,9 +1158,9 @@ so that window splits happen relative to the spawner, not the current window.
 Returns the buffer name of the new session, or nil if folder doesn't exist.
 
 Note: `meta-agent-shell-start-function' must:
-- Accept (ARG BUFFER-NAME) where ARG is passed as first argument
+- Accept (ARG &optional BUFFER-NAME), or tolerate an omitted ARG
 - Recognize \\='use-current-dir as ARG to use `default-directory' without
-  triggering container mode (as opposed to \\='(16) which may enable containers)
+  treating it as container mode (unlike \\='(16), which may do so)
 - Accept BUFFER-NAME as the second argument for naming the buffer"
   (let ((dir (expand-file-name folder)))
     (if (file-directory-p dir)
@@ -840,39 +1194,44 @@ Note: `meta-agent-shell-start-function' must:
           ;; This may change selected window/buffer, so run before binding default-directory
           (run-hooks 'meta-agent-shell-before-spawn-hook)
           (let* ((default-directory dir)
-                 (project-name (file-name-nondirectory (directory-file-name dir)))
                  (buffer-name name)
                  ;; Signal "use current directory" without container mode
-                 (start-arg 'use-current-dir))
+                 (start-arg 'use-current-dir)
+                 (buf nil)
+                 (actual-buffer-name nil))
             ;; Pass buffer-name as second arg to start function
             ;; Workaround: agent-shell may fail if a buffer with this name was
             ;; recently killed (async cleanup race). Retry once after brief delay.
             (condition-case err
-                (funcall meta-agent-shell-start-function
-                         start-arg
-                         buffer-name)
+                (setq buf
+                      (meta-agent-shell--call-start-function
+                       start-arg
+                       buffer-name))
               (error
                (message "Agent start failed (%s), retrying after cleanup delay..." err)
                (sit-for 0.5)  ; allow pending events to process
-               (funcall meta-agent-shell-start-function
-                        start-arg
-                        buffer-name)))
+               (setq buf
+                     (meta-agent-shell--call-start-function
+                      start-arg
+                      buffer-name))))
+            (setq actual-buffer-name (buffer-name buf))
             ;; Auto-register if restrictions are enabled or explicitly requested
             (when (or auto-allow meta-agent-shell-restrict-targets)
-              (meta-agent-shell-allow-target buffer-name))
+              (meta-agent-shell-allow-target actual-buffer-name))
             ;; Run after-spawn hook (e.g., for post-spawn setup)
-            (run-hooks 'meta-agent-shell-after-spawn-hook)
+            (with-current-buffer buf
+              (run-hooks 'meta-agent-shell-after-spawn-hook))
             ;; Track initial task for killed agent persistence
             (when initial-message
-              (puthash (buffer-name (current-buffer)) initial-message
+              (puthash actual-buffer-name initial-message
                        meta-agent-shell--initial-tasks)
               (run-at-time 0.5 nil
                            (lambda (buf msg)
                              (when (buffer-live-p buf)
                                (with-current-buffer buf
                                  (shell-maker-submit :input msg))))
-                           (current-buffer) initial-message))
-            (buffer-name (current-buffer))))
+                           buf initial-message))
+            actual-buffer-name))
       (message "Directory does not exist: %s" dir)
       nil)))
 
@@ -1033,16 +1392,17 @@ outgoing-request-decorator, so they persist across context compaction."
              (buf nil))
         ;; Use the configured start function to create the buffer
         (condition-case err
-            (funcall meta-agent-shell-start-function
-                     (car meta-agent-shell-start-function-args)
-                     dispatcher-buffer-name)
+            (setq buf
+                  (meta-agent-shell--call-start-function
+                   (car meta-agent-shell-start-function-args)
+                   dispatcher-buffer-name))
           (error
            (message "Dispatcher start failed (%s), retrying after cleanup delay..." err)
            (sit-for 0.5)
-           (funcall meta-agent-shell-start-function
-                    (car meta-agent-shell-start-function-args)
-                    dispatcher-buffer-name)))
-        (setq buf (current-buffer))
+           (setq buf
+                 (meta-agent-shell--call-start-function
+                  (car meta-agent-shell-start-function-args)
+                  dispatcher-buffer-name))))
         ;; Register dispatcher
         (push (cons project-path buf) meta-agent-shell--dispatchers)
         (message "Dispatcher started for %s (instructions in system prompt)" project-name)
@@ -1083,7 +1443,7 @@ Prefix ARG is passed through to the start function."
                   (args (if arg
                             (cons arg (cdr meta-agent-shell-start-function-args))
                           meta-agent-shell-start-function-args)))
-              (apply meta-agent-shell-start-function args))
+              (apply #'meta-agent-shell--call-start-function args))
           ;; No dispatcher, start one
           (meta-agent-shell-start-dispatcher project-path))))))
 

--- a/meta-agent-shell.el
+++ b/meta-agent-shell.el
@@ -5,7 +5,7 @@
 ;; Author: Elle Najt
 ;; URL: https://github.com/ElleNajt/meta-agent-shell
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "29.1") (agent-shell "0.33.1"))
+;; Package-Requires: ((emacs "29.1") (agent-shell "0.46.1"))
 ;; Keywords: convenience, tools, ai
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
## Description

This provides a 'batteries included' wrapper for starting `agent-shell` and an Emacs-native bootstrap option. Users can still point it at a fully custom starter if they want.

**Main changes**
- Adds `meta-agent-shell-setup` as an Emacs-native alternative to the current setup script
- Adds a package-owned default wrapper around `agent-shell-start`
- Preserves the startup behavior `meta-agent-shell` expects for:
  - buffer naming
  - project-root vs current-directory startup
  - the internal `'use-current-dir` path used for programmatic named-agent starts
- Adds package-owned customization points for ergonomic editing of the startup wrapper
  - Codex defaults rely on a pre-release `agent-shell` variable. Latest version `0.46.1` specified for now.
- Updates README docs for setup and customization
- Adds focused test coverage for these changes

**Additional changes**
- Updated `meta-agent-shell-test-ask-session`
- Made the following tests more durable in sandboxed environments:
  - `meta-agent-shell-test-view-session`
  - `meta-agent-shell-test-close-session`
  - `meta-agent-shell-test-full-workflow`

## Maintainer notes

- The default wrapper is based on the maintainer’s starter which was referenced in code. **EDIT** My general approach on the customization points was "would this or other common use cases be possible and ergonomic." @ElleNajt if I missed some necessary details or style preferences, I'm happy to make changes. Users who prefer their own starter can still do something like:

```elisp
(setq meta-agent-shell-start-function
      #'my/agent-shell-anthropic-start-claude-code)
```

- I considered taking additional steps to make this more agent-agnostic, but figured it would be better as its own effort. 

## Type of Changes
- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Code refactoring

## Related Issues
Fixes #1 

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

Ran:
```bash
emacs -Q -batch -L . -l ert -l meta-agent-shell-test.el -f ert-run-tests-batch-and-exit
```